### PR TITLE
Declare function variables at the beginning of a scope block

### DIFF
--- a/src/zfp.c
+++ b/src/zfp.c
@@ -882,6 +882,7 @@ zfp_compress(zfp_stream* zfp, const zfp_field* field)
   uint strided = zfp_field_stride(field, NULL);
   uint dims = zfp_field_dimensionality(field);
   uint type = field->type;
+  void (*compress)(zfp_stream*, const zfp_field*);
 
   switch (type) {
     case zfp_type_int32:
@@ -894,7 +895,7 @@ zfp_compress(zfp_stream* zfp, const zfp_field* field)
   }
 
   /* return 0 if compression mode is not supported */
-  void (*compress)(zfp_stream*, const zfp_field*) = ftable[exec][strided][dims - 1][type - zfp_type_int32];
+  compress = ftable[exec][strided][dims - 1][type - zfp_type_int32];
   if (!compress)
     return 0;
 
@@ -941,6 +942,7 @@ zfp_decompress(zfp_stream* zfp, zfp_field* field)
   uint strided = zfp_field_stride(field, NULL);
   uint dims = zfp_field_dimensionality(field);
   uint type = field->type;
+  void (*decompress)(zfp_stream*, zfp_field*);
 
   switch (type) {
     case zfp_type_int32:
@@ -953,7 +955,7 @@ zfp_decompress(zfp_stream* zfp, zfp_field* field)
   }
 
   /* return 0 if decompression mode is not supported */
-  void (*decompress)(zfp_stream*, zfp_field*) = ftable[exec][strided][dims - 1][type - zfp_type_int32];
+  decompress = ftable[exec][strided][dims - 1][type - zfp_type_int32];
   if (!decompress)
     return 0;
 


### PR DESCRIPTION
Fix compile errors with Visual Studio 2008 and 2010.