### PR TITLE
Fix RuntimeError using int64 in zfpy on Windows

### DIFF
--- a/python/zfpy.pyx
+++ b/python/zfpy.pyx
@@ -51,11 +51,11 @@ cpdef dtype_to_ztype(dtype):
 
 cpdef dtype_to_format(dtype):
     # format characters detailed here:
-    # https://docs.python.org/2/library/array.html#module-array
+    # https://docs.python.org/3/library/array.html
     if dtype == np.int32:
         return 'i' # signed int
     elif dtype == np.int64:
-        return 'l' # signed long
+        return 'q' # signed long long
     elif dtype == np.float32:
         return 'f' # float
     elif dtype == np.float64:


### PR DESCRIPTION
Thank you for releasing ZFP 0.5.5 with Python bindings!

I built zfpy-0.5.5 on Windows for Python 3.x without problems.

This PR fixes two test errors of type `RuntimeError: Item size 8 for PEP 3118 buffer format string l does not match the dtype l item size 4`. The reason for the failures is that, on Windows, the `C long` type is 4 bytes only.

~~The proposed fix works on Python >=3.3 only. But then, Python 2.7 will no longer be maintained from next year on, and zfp-0.5.5 does not build with Visual Studio 2008 (required for Python 2.7 compatibility on Windows) without code changes.~~

Btw, if you have not done so, you may want to register the name `zfpy` on [PyPI](https://pypi.org) before someone squats the name.

```
================================================= test session starts =================================================
platform win32 -- Python 3.7.3, pytest-4.4.1, py-1.8.0, pluggy-0.9.0
<snip>
collected 5 items

..\test_numpy.py ...FF                                                                                           [100%]

====================================================== FAILURES =======================================================
___________________________________________ TestNumpy.test_different_dtypes ___________________________________________

self = <zfpy.test_numpy.TestNumpy testMethod=test_different_dtypes>

    def test_different_dtypes(self):
        shape = (5, 5)
        num_elements = shape[0] * shape[1]

        for dtype in [np.float32, np.float64]:
            elements = np.random.random_sample(num_elements)
            elements = elements.astype(dtype, casting="same_kind")
            array = np.reshape(elements, newshape=shape)
            self.lossless_round_trip(array)

        if (version_parse is not None and
            (version_parse(np.__version__) >= version_parse("1.11.0"))
        ):
            for dtype in [np.int32, np.int64]:
                array = np.random.randint(2**30, size=shape, dtype=dtype)
>               self.lossless_round_trip(array)

X:\Python37\lib\site-packages\zfpy\test_numpy.py:45:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
X:\Python37\lib\site-packages\zfpy\test_numpy.py:17: in lossless_round_trip
    decompressed_array = zfpy.decompress_numpy(compressed_array)
zfpy\zfpy.pyx:331: in zfpy.zfpy.decompress_numpy
    ???
zfpy\zfpy.pyx:349: in zfpy.zfpy.decompress_numpy
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

a = <[AttributeError("'zfpy.zfpy.memoryview' object has no attribute 'typecode'") raised in repr()] SafeRepr object at 0x227160bb390>
dtype = None, order = None

    def asarray(a, dtype=None, order=None):
        """Convert the input to an array.

        Parameters
        ----------
        a : array_like
            Input data, in any form that can be converted to an array.  This
            includes lists, lists of tuples, tuples, tuples of tuples, tuples
            of lists and ndarrays.
        dtype : data-type, optional
            By default, the data-type is inferred from the input data.
        order : {'C', 'F'}, optional
            Whether to use row-major (C-style) or
            column-major (Fortran-style) memory representation.
            Defaults to 'C'.

        Returns
        -------
        out : ndarray
            Array interpretation of `a`.  No copy is performed if the input
            is already an ndarray with matching dtype and order.  If `a` is a
            subclass of ndarray, a base class ndarray is returned.

        See Also
        --------
        asanyarray : Similar function which passes through subclasses.
        ascontiguousarray : Convert input to a contiguous array.
        asfarray : Convert input to a floating point ndarray.
        asfortranarray : Convert input to an ndarray with column-major
                         memory order.
        asarray_chkfinite : Similar function which checks input for NaNs and Infs.
        fromiter : Create an array from an iterator.
        fromfunction : Construct an array by executing a function on grid
                       positions.

        Examples
        --------
        Convert a list into an array:

        >>> a = [1, 2]
        >>> np.asarray(a)
        array([1, 2])

        Existing arrays are not copied:

        >>> a = np.array([1, 2])
        >>> np.asarray(a) is a
        True

        If `dtype` is set, array is copied only if dtype does not match:

        >>> a = np.array([1, 2], dtype=np.float32)
        >>> np.asarray(a, dtype=np.float32) is a
        True
        >>> np.asarray(a, dtype=np.float64) is a
        False

        Contrary to `asanyarray`, ndarray subclasses are not passed through:

        >>> issubclass(np.recarray, np.ndarray)
        True
        >>> a = np.array([(1.0, 2), (3.0, 4)], dtype='f4,i4').view(np.recarray)
        >>> np.asarray(a) is a
        False
        >>> np.asanyarray(a) is a
        True

        """
>       return array(a, dtype, copy=False, order=order)
E       RuntimeError: Item size 8 for PEP 3118 buffer format string l does not match the dtype l item size 4.

X:\Python37\lib\site-packages\numpy\core\numeric.py:501: RuntimeError
________________________________________________ TestNumpy.test_utils _________________________________________________

self = <zfpy.test_numpy.TestNumpy testMethod=test_utils>

    def test_utils(self):
        for ndims in range(1, 5):
            for ztype, ztype_str in [
                    (zfpy.type_float,  "float"),
                    (zfpy.type_double, "double"),
                    (zfpy.type_int32,  "int32"),
                    (zfpy.type_int64,  "int64"),
            ]:
                orig_random_array = test_utils.getRandNumpyArray(ndims, ztype)
                orig_checksum = test_utils.getChecksumOrigArray(ndims, ztype)
                actual_checksum = test_utils.hashNumpyArray(orig_random_array)
                self.assertEqual(orig_checksum, actual_checksum)

                for stride_str, stride_config in [
                        ("as_is", test_utils.stride_as_is),
                        ("permuted", test_utils.stride_permuted),
                        ("interleaved", test_utils.stride_interleaved),
                        #("reversed", test_utils.stride_reversed),
                ]:
                    # permuting a 1D array is not supported
                    if stride_config == test_utils.stride_permuted and ndims == 1:
                        continue
                    random_array = test_utils.generateStridedRandomNumpyArray(
                        stride_config,
                        orig_random_array
                    )
                    self.assertTrue(np.equal(orig_random_array, random_array).all())

                    for compress_param_num in range(3):
                        modes = [(zfpy.mode_fixed_accuracy, "tolerance"),
                                 (zfpy.mode_fixed_precision, "precision"),
                                 (zfpy.mode_fixed_rate, "rate")]
                        if ztype in [zfpy.type_int32, zfpy.type_int64]:
                            modes = [modes[-1]] # only fixed-rate is supported for integers
                        for mode, mode_str in modes:
                            # Compression
                            compression_kwargs = {
                                mode_str: test_utils.computeParameterValue(
                                    mode,
                                    compress_param_num
                                ),
                            }

                            compressed_array = zfpy.compress_numpy(
                                random_array,
                                write_header=False,
                                **compression_kwargs
                            )
                            compressed_checksum = test_utils.getChecksumCompArray(
                                ndims,
                                ztype,
                                mode,
                                compress_param_num
                            )
                            actual_checksum = test_utils.hashCompressedArray(
                                compressed_array
                            )
                            self.assertEqual(compressed_checksum, actual_checksum)

                            # Decompression
                            decompressed_checksum = test_utils.getChecksumDecompArray(
                                ndims,
                                ztype,
                                mode,
                                compress_param_num
                            )

                            # Decompression using the "public" interface
                            # requires a header, so re-compress with the header
                            # included in the stream
                            compressed_array = zfpy.compress_numpy(
                                random_array,
                                write_header=True,
                                **compression_kwargs
                            )
                            decompressed_array = zfpy.decompress_numpy(
>                               compressed_array,
                            )

X:\Python37\lib\site-packages\zfpy\test_numpy.py:183:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
zfpy\zfpy.pyx:331: in zfpy.zfpy.decompress_numpy
    ???
zfpy\zfpy.pyx:349: in zfpy.zfpy.decompress_numpy
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

a = <[AttributeError("'zfpy.zfpy.memoryview' object has no attribute 'typecode'") raised in repr()] SafeRepr object at 0x227160b5b38>
dtype = None, order = None

    def asarray(a, dtype=None, order=None):
        """Convert the input to an array.

        Parameters
        ----------
        a : array_like
            Input data, in any form that can be converted to an array.  This
            includes lists, lists of tuples, tuples, tuples of tuples, tuples
            of lists and ndarrays.
        dtype : data-type, optional
            By default, the data-type is inferred from the input data.
        order : {'C', 'F'}, optional
            Whether to use row-major (C-style) or
            column-major (Fortran-style) memory representation.
            Defaults to 'C'.

        Returns
        -------
        out : ndarray
            Array interpretation of `a`.  No copy is performed if the input
            is already an ndarray with matching dtype and order.  If `a` is a
            subclass of ndarray, a base class ndarray is returned.

        See Also
        --------
        asanyarray : Similar function which passes through subclasses.
        ascontiguousarray : Convert input to a contiguous array.
        asfarray : Convert input to a floating point ndarray.
        asfortranarray : Convert input to an ndarray with column-major
                         memory order.
        asarray_chkfinite : Similar function which checks input for NaNs and Infs.
        fromiter : Create an array from an iterator.
        fromfunction : Construct an array by executing a function on grid
                       positions.

        Examples
        --------
        Convert a list into an array:

        >>> a = [1, 2]
        >>> np.asarray(a)
        array([1, 2])

        Existing arrays are not copied:

        >>> a = np.array([1, 2])
        >>> np.asarray(a) is a
        True

        If `dtype` is set, array is copied only if dtype does not match:

        >>> a = np.array([1, 2], dtype=np.float32)
        >>> np.asarray(a, dtype=np.float32) is a
        True
        >>> np.asarray(a, dtype=np.float64) is a
        False

        Contrary to `asanyarray`, ndarray subclasses are not passed through:

        >>> issubclass(np.recarray, np.ndarray)
        True
        >>> a = np.array([(1.0, 2), (3.0, 4)], dtype='f4,i4').view(np.recarray)
        >>> np.asarray(a) is a
        False
        >>> np.asanyarray(a) is a
        True

        """
>       return array(a, dtype, copy=False, order=order)
E       RuntimeError: Item size 8 for PEP 3118 buffer format string l does not match the dtype l item size 4.

X:\Python37\lib\site-packages\numpy\core\numeric.py:501: RuntimeError
========================================= 2 failed, 3 passed in 7.74 seconds ==========================================
```