### PR TITLE
CUDA optimization: unrolling optimization gather_partial functions

### DIFF
--- a/src/cuda_zfp/encode1.cuh
+++ b/src/cuda_zfp/encode1.cuh
@@ -17,8 +17,8 @@ __device__ __host__ inline
 void gather_partial1(Scalar* q, const Scalar* p, int nx, int sx)
 {
   uint x;
-  for (x = 0; x < 4; x++, p += sx)
-    if (x < nx) q[x] = *p;
+  for (x = 0; x < 4; x++)
+    if (x < nx) q[x] = p[x * sx];
   pad_block(q, nx, 1);
 }
 
@@ -131,7 +131,7 @@ size_t encode1launch(uint dim,
   cudaEventRecord(start);
 #endif
 
-	cudaEncode1<Scalar> << <grid_size, block_size>> >
+  cudaEncode1<Scalar> <<<grid_size, block_size>>>
     (maxbits,
      d_data,
      stream,

--- a/src/cuda_zfp/encode1.cuh
+++ b/src/cuda_zfp/encode1.cuh
@@ -17,8 +17,8 @@ __device__ __host__ inline
 void gather_partial1(Scalar* q, const Scalar* p, int nx, int sx)
 {
   uint x;
-  for (x = 0; x < nx; x++, p += sx)
-    q[x] = *p;
+  for (x = 0; x < 4; x++, p += sx)
+    if (x < nx) q[x] = *p;
   pad_block(q, nx, 1);
 }
 

--- a/src/cuda_zfp/encode2.cuh
+++ b/src/cuda_zfp/encode2.cuh
@@ -17,11 +17,12 @@ __device__ __host__ inline
 void gather_partial2(Scalar* q, const Scalar* p, int nx, int ny, int sx, int sy)
 {
   uint x, y;
-  for (y = 0; y < ny; y++, p += sy - nx * sx) {
-    for (x = 0; x < nx; x++, p += sx)
-      q[4 * y + x] = *p;
+  for (y = 0; y < 4; y++, p += sy - nx * sx)
+    if (y < ny) {
+      for (x = 0; x < 4; x++, p += sx)
+        if (x < nx) q[4 * y + x] = *p;
       pad_block(q + 4 * y, nx, 1);
-  }
+    }
   for (x = 0; x < 4; x++)
     pad_block(q + x, ny, 4);
 }

--- a/src/cuda_zfp/encode2.cuh
+++ b/src/cuda_zfp/encode2.cuh
@@ -17,11 +17,15 @@ __device__ __host__ inline
 void gather_partial2(Scalar* q, const Scalar* p, int nx, int ny, int sx, int sy)
 {
   uint x, y;
-  for (y = 0; y < 4; y++, p += sy - nx * sx)
+  for (y = 0; y < 4; y++)
     if (y < ny) {
-      for (x = 0; x < 4; x++, p += sx)
-        if (x < nx) q[4 * y + x] = *p;
+      for (x = 0; x < 4; x++)
+        if (x < nx) {
+          q[4 * y + x] = *p;//[x * sx];
+          p += sx;
+        }
       pad_block(q + 4 * y, nx, 1);
+      p += sy - nx * sx;
     }
   for (x = 0; x < 4; x++)
     pad_block(q + x, ny, 4);
@@ -144,7 +148,7 @@ size_t encode2launch(uint2 dims,
   cudaEventRecord(start);
 #endif
 
-	cudaEncode2<Scalar> << <grid_size, block_size>> >
+  cudaEncode2<Scalar> <<<grid_size, block_size>>>
     (maxbits,
      d_data,
      stream,

--- a/src/cuda_zfp/encode3.cuh
+++ b/src/cuda_zfp/encode3.cuh
@@ -14,16 +14,21 @@ __device__ __host__ inline
 void gather_partial3(Scalar* q, const Scalar* p, int nx, int ny, int nz, int sx, int sy, int sz)
 {
   uint x, y, z;
-  for (z = 0; z < 4; z++, p += sz - ny * sy)
+  for (z = 0; z < 4; z++)
     if (z < nz) {
-      for (y = 0; y < 4; y++, p += sy - nx * sx)
+      for (y = 0; y < 4; y++)
         if (y < ny) {
-          for (x = 0; x < 4; x++, p += sx)
-            if (x < nx) q[16 * z + 4 * y + x] = *p;
+          for (x = 0; x < 4; x++)
+            if (x < nx) {
+              q[16 * z + 4 * y + x] = *p;
+              p += sx;
+          }
+          p += sy - nx * sx;
           pad_block(q + 16 * z + 4 * y, nx, 1);
         }
       for (x = 0; x < 4; x++)
         pad_block(q + 16 * z + x, ny, 4);
+      p += sz - ny * sy;
     }
   for (y = 0; y < 4; y++)
     for (x = 0; x < 4; x++)


### PR DESCRIPTION
Optimization of CUDA encoder.  The `gather_partial` functions use a runtime variable for their for loop trip count.  This means the compiler cannot unroll the loops and this results in register spillage since the compiler cannot index into registers.

This optimization leads to a 1.18x speedup on the benchmark when running on GP100
`zfp -d -3 384 384 256 -r 16 -x cuda -i ~/zfp/viscosity.raw`