### PR TITLE
Add short note and link for h5z-zfp

### DIFF
--- a/docs/source/zfpcmd.rst
+++ b/docs/source/zfpcmd.rst
@@ -5,6 +5,11 @@
 File Compression
 ================
 
+This section describes a simple, file-based |zfp| compression tool that is
+part of the |zfp| distribution named |zfpcmd|. If you are interested in
+other, third-party, file-based compression options, please be sure to read
+about those mentioned in the :ref:`Overview <overview>` section.
+
 The |zfpcmd| executable in the :file:`bin` directory is primarily
 intended for evaluating the rate-distortion (compression ratio and quality)
 provided by the compressor, but since version 0.5.0 also allows reading and
@@ -253,8 +258,7 @@ Examples
   * :code:`-d -1 1000000 -c 64 64 0 -1074` : 4x fixed-rate compression of 1,000,000 doubles
   * :code:`-x omp=16,256` : parallel compression with 16 threads, 256-block chunks
 
-HDF5 Files and H5Z-ZFP Filter
------------------------------
-Users may also find the `H5Z-ZFP <https://github.com/LLNL/H5Z-ZFP>`_ compression
-filter for `HDF5 <https://portal.hdfgroup.org/display/support`_ files useful in
-managing |zfp| compression within files.
+Third party, file-based |zfp| compression
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Several additional, third-party options for using |zfp| to compress data to files
+are described in the :ref:`Overview <overview>` section.

--- a/docs/source/zfpcmd.rst
+++ b/docs/source/zfpcmd.rst
@@ -2,8 +2,8 @@
 
 .. _zfpcmd:
 
-File Compressor
-===============
+File Compression
+================
 
 The |zfpcmd| executable in the :file:`bin` directory is primarily
 intended for evaluating the rate-distortion (compression ratio and quality)
@@ -252,3 +252,9 @@ Examples
   * :code:`-d -1 1000000 -a 1e-9` : compression of 1,000,000 doubles with < 10\ :sup:`-9` max error
   * :code:`-d -1 1000000 -c 64 64 0 -1074` : 4x fixed-rate compression of 1,000,000 doubles
   * :code:`-x omp=16,256` : parallel compression with 16 threads, 256-block chunks
+
+HDF5 Files and H5Z-ZFP Filter
+-----------------------------
+Users may also find the `H5Z-ZFP <https://github.com/LLNL/H5Z-ZFP>`_ compression
+filter for `HDF5 <https://portal.hdfgroup.org/display/support`_ files useful in
+managing |zfp| compression within files.


### PR DESCRIPTION
Wasn't sure of best place to put. Added to end of section on the zfp file compression command. I adjusted the title of the section slightly so that it was a little more inclusive.