### PR TITLE
Remove redundant CUDA h2d transfers

### DIFF
--- a/src/cuda_zfp/cuZFP.cu
+++ b/src/cuda_zfp/cuZFP.cu
@@ -195,7 +195,7 @@ size_t decode(uint ndims[3], int3 stride, int bits_per_block, Word *stream, T *o
   return stream_bytes;
 }
 
-Word *setup_device_stream(zfp_stream *stream,const zfp_field *field)
+Word *setup_device_stream_compress(zfp_stream *stream,const zfp_field *field)
 {
   bool stream_device = cuZFP::is_gpu_ptr(stream->stream->begin);
   assert(sizeof(word) == sizeof(Word)); // "CUDA version currently only supports 64bit words");
@@ -203,13 +203,29 @@ Word *setup_device_stream(zfp_stream *stream,const zfp_field *field)
   if(stream_device)
   {
     return (Word*) stream->stream->begin;
-  } 
+  }
 
   Word *d_stream = NULL;
-  // TODO: we we have a real stream we can just ask it how big it is
   size_t max_size = zfp_stream_maximum_size(stream, field);
   cudaMalloc(&d_stream, max_size);
-  cudaMemcpy(d_stream, stream->stream->begin, max_size, cudaMemcpyHostToDevice);
+  return d_stream;
+}
+
+Word *setup_device_stream_decompress(zfp_stream *stream,const zfp_field *field)
+{
+  bool stream_device = cuZFP::is_gpu_ptr(stream->stream->begin);
+  assert(sizeof(word) == sizeof(Word)); // "CUDA version currently only supports 64bit words");
+
+  if(stream_device)
+  {
+    return (Word*) stream->stream->begin;
+  }
+
+  Word *d_stream = NULL;
+  //TODO: change maximum_size to compressed stream size
+  size_t size = zfp_stream_maximum_size(stream, field);
+  cudaMalloc(&d_stream, size);
+  cudaMemcpy(d_stream, stream->stream->begin, size, cudaMemcpyHostToDevice);
   return d_stream;
 }
 
@@ -239,7 +255,7 @@ void * offset_void(zfp_type type, void *ptr, long long int offset)
   return offset_ptr;
 }
 
-void *setup_device_field(const zfp_field *field, const int3 &stride, long long int &offset)
+void *setup_device_field_compress(const zfp_field *field, const int3 &stride, long long int &offset)
 {
   bool field_device = cuZFP::is_gpu_ptr(field->data);
 
@@ -280,6 +296,43 @@ void *setup_device_field(const zfp_field *field, const int3 &stride, long long i
   return offset_void(field->type, d_data, -offset);
 }
 
+void *setup_device_field_decompress(const zfp_field *field, const int3 &stride, long long int &offset)
+{
+  bool field_device = cuZFP::is_gpu_ptr(field->data);
+
+  if(field_device)
+  {
+    offset = 0;
+    return field->data;
+  }
+
+  uint dims[3];
+  dims[0] = field->nx;
+  dims[1] = field->ny;
+  dims[2] = field->nz;
+
+  size_t type_size = zfp_type_size(field->type);
+
+  size_t field_size = 1;
+  for(int i = 0; i < 3; ++i)
+  {
+    if(dims[i] != 0)
+    {
+      field_size *= dims[i];
+    }
+  }
+
+  bool contig = internal::is_contigous(dims, stride, offset);
+
+  void *d_data = NULL;
+  if(contig)
+  {
+    size_t field_bytes = type_size * field_size;
+    cudaMalloc(&d_data, field_bytes);
+  }
+  return offset_void(field->type, d_data, -offset);
+}
+
 void cleanup_device_ptr(void *orig_ptr, void *d_ptr, size_t bytes, long long int offset, zfp_type type)
 {
   bool device = cuZFP::is_gpu_ptr(orig_ptr);
@@ -316,7 +369,7 @@ cuda_compress(zfp_stream *stream, const zfp_field *field)
   
   size_t stream_bytes = 0;
   long long int offset = 0; 
-  void *d_data = internal::setup_device_field(field, stride, offset);
+  void *d_data = internal::setup_device_field_compress(field, stride, offset);
 
   if(d_data == NULL)
   {
@@ -324,7 +377,7 @@ cuda_compress(zfp_stream *stream, const zfp_field *field)
     return 0;
   }
 
-  Word *d_stream = internal::setup_device_stream(stream, field);
+  Word *d_stream = internal::setup_device_stream_compress(stream, field);
 
   if(field->type == zfp_type_float)
   {
@@ -375,7 +428,7 @@ cuda_decompress(zfp_stream *stream, zfp_field *field)
 
   size_t decoded_bytes = 0;
   long long int offset = 0;
-  void *d_data = internal::setup_device_field(field, stride, offset);
+  void *d_data = internal::setup_device_field_decompress(field, stride, offset);
   
   if(d_data == NULL)
   {
@@ -383,7 +436,7 @@ cuda_decompress(zfp_stream *stream, zfp_field *field)
     return;
   }
 
-  Word *d_stream = internal::setup_device_stream(stream, field);
+  Word *d_stream = internal::setup_device_stream_decompress(stream, field);
 
   if(field->type == zfp_type_float)
   {


### PR DESCRIPTION
This patch removes redundant CUDA h2d transfers by creating separate
field and stream setup functions for compression and decompresion.
This will also allow more optimizations in later patches.