### PR TITLE
hotfix: Fix wrong memset params order

### DIFF
--- a/tests/src/decode/zfpDecodeBlockBase.c
+++ b/tests/src/decode/zfpDecodeBlockBase.c
@@ -266,7 +266,7 @@ _catFunc3(given_, DIM_INT_STR, Block_when_DecodeSpecialBlocks_expect_ArraysMatch
     free(decodedDataArr);
 
     // reset/zero bitstream, rewind for next iteration
-    memset(bundle->buffer, bundle->bufsizeBytes, 0);
+    memset(bundle->buffer, 0, bundle->bufsizeBytes);
     zfp_stream_rewind(stream);
   }
 

--- a/tests/src/encode/zfpEncodeBlockBase.c
+++ b/tests/src/encode/zfpEncodeBlockBase.c
@@ -254,7 +254,7 @@ _catFunc3(given_, DIM_INT_STR, Block_when_EncodeSpecialBlocks_expect_BitstreamCh
     }
 
     // reset/zero bitstream, rewind for next iteration
-    memset(bundle->buffer, bundle->bufsizeBytes, 0);
+    memset(bundle->buffer, 0, bundle->bufsizeBytes);
     zfp_stream_rewind(stream);
   }
 


### PR DESCRIPTION
The init value and length parameters of memset were swapped.
This commit fixes that.

Signed-off-by: Mohamed A. Bamakhrama <mohamed@alumni.tum.de>