### PR TITLE
replace bytes of compressed stream with uint8_t

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -296,6 +296,7 @@ script:
     if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$PYTHON_VERSION" = "3.5" ]; then
         export PYTHON_INCLUDE_DIR=/usr/include/python3.5m;
         export PYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.5m.so;
+        sudo $PYTHON_EXECUTABLE -m pip install --upgrade pip;
         sudo $PYTHON_EXECUTABLE -m pip install --upgrade cython3;
     fi
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -296,7 +296,7 @@ script:
     if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$PYTHON_VERSION" = "3.5" ]; then
         export PYTHON_INCLUDE_DIR=/usr/include/python3.5m;
         export PYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.5m.so;
-        sudo $PYTHON_EXECUTABLE -m pip3 install --upgrade cython3;
+        sudo $PYTHON_EXECUTABLE -m pip install --upgrade cython3;
     fi
   - |
     if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$DISTRIB_CODENAME" = "trusty" ] && [ "$PYTHON_VERSION" = "2.7" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
             - libpython3.5-dev
             - cython3
             - python3-numpy
+            - python-pip
       env: CC='gcc-6' CXX='g++-6' FC='gfortran-6' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5' COVERAGE='ON'
 
     - os: linux
@@ -31,6 +32,7 @@ matrix:
             - libpython3.5-dev
             - cython3
             - python3-numpy
+            - python-pip
       env: CC='clang-3.6' CXX='clang++-3.6' FC='gfortran-6' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5'
 
     - os: linux
@@ -48,6 +50,7 @@ matrix:
             - libpython3.5-dev
             - cython3
             - python3-numpy
+            - python-pip
       env: CC='clang-4.0' CXX='clang++-4.0' FC='gfortran-6' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5'
 
     - os: linux
@@ -63,7 +66,7 @@ matrix:
             - libpython3.5-dev
             - cython3
             - python3-numpy
-            - pip
+            - python-pip
       env: CC='gcc-4.4' CXX='g++-4.4' FC='gfortran-4.4' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5'
 
     - os: linux
@@ -79,6 +82,7 @@ matrix:
             - libpython3.5-dev
             - cython3
             - python3-numpy
+            - python-pip
       env: CC='gcc-4.7' CXX='g++-4.7' FC='gfortran-4.7' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5'
 
     - os: linux
@@ -94,6 +98,7 @@ matrix:
             - libpython3.5-dev
             - cython3
             - python3-numpy
+            - python-pip
       env: CC='gcc-4.8' CXX='g++-4.8' FC='gfortran-4.8' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5'
 
     - os: linux
@@ -109,6 +114,7 @@ matrix:
             - libpython3.5-dev
             - cython3
             - python3-numpy
+            - python-pip
       env: CC='gcc-4.9' CXX='g++-4.9' FC='gfortran-4.9' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5'
 
     - os: linux
@@ -152,6 +158,7 @@ matrix:
             - libpython3.5-dev
             - cython3
             - python3-numpy
+            - python-pip
       env: CC='gcc-6' CXX='g++-6' FC='gfortran-6' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5' C_STANDARD='90'
 
     - os: linux
@@ -167,6 +174,7 @@ matrix:
             - libpython3.5-dev
             - cython3
             - python3-numpy
+            - python-pip
       env: CC='gcc-6' CXX='g++-6' FC='gfortran-6' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5' C_STANDARD='11'
 
     - os: linux
@@ -182,6 +190,7 @@ matrix:
             - libpython3.5-dev
             - cython3
             - python3-numpy
+            - python-pip
       env: CC='gcc-6' CXX='g++-6' FC='gfortran-6' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5' CXX_STANDARD='11'
 
     - os: linux
@@ -197,6 +206,7 @@ matrix:
             - libpython3.5
             - cython3
             - python3-numpy
+            - python-pip
       env: CC='gcc-6' CXX='g++-6' FC='gfortran-6' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5' CXX_STANDARD='14'
 
     - os: linux
@@ -212,6 +222,7 @@ matrix:
             - libpython3.5
             - cython3
             - python3-numpy
+            - python-pip
       env: CC='gcc-6' CXX='g++-6' FC='gfortran-6' FORTRAN_STANDARD='2008' PYTHON_VERSION='3.5'
 
     - os: linux
@@ -227,6 +238,7 @@ matrix:
             - libpython3.5
             - cython3
             - python3-numpy
+            - python-pip
       env: CC='gcc-7' CXX='g++-7' FC='gfortran-7' FORTRAN_STANDARD='2008' PYTHON_VERSION='3.5'
 
     - os: osx
@@ -282,11 +294,15 @@ script:
     if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$PYTHON_VERSION" = "2.7" ]; then
         export PYTHON_INCLUDE_DIR=/usr/include/python2.7;
         export PYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython2.7.so;
+        sudo $PYTHON_EXECUTABLE -m pip install --upgrade pip;
+        sudo $PYTHON_EXECUTABLE -m pip install --upgrade cython3;
     fi
   - |
     if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$PYTHON_VERSION" = "3.5" ]; then
         export PYTHON_INCLUDE_DIR=/usr/include/python3.5m;
         export PYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.5m.so;
+        sudo $PYTHON_EXECUTABLE -m pip install --upgrade pip;
+        sudo $PYTHON_EXECUTABLE -m pip install --upgrade cython3;
     fi
   - |
     if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$DISTRIB_CODENAME" = "trusty" ] && [ "$PYTHON_VERSION" = "2.7" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -297,7 +297,7 @@ script:
         export PYTHON_INCLUDE_DIR=/usr/include/python3.5m;
         export PYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.5m.so;
         sudo $PYTHON_EXECUTABLE -m pip install --upgrade pip;
-        sudo $PYTHON_EXECUTABLE -m pip install --upgrade cython3;
+        sudo $PYTHON_EXECUTABLE -m pip install --upgrade cython;
     fi
   - |
     if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$DISTRIB_CODENAME" = "trusty" ] && [ "$PYTHON_VERSION" = "2.7" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,7 @@ matrix:
             - libpython3.5-dev
             - cython3
             - python3-numpy
+            - pip
       env: CC='gcc-4.4' CXX='g++-4.4' FC='gfortran-4.4' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5'
 
     - os: linux
@@ -274,6 +275,8 @@ script:
     if [ "$TRAVIS_OS_NAME" = "linux" ]; then
         export PYTHON_EXECUTABLE=/usr/bin/python$PYTHON_VERSION;
         source /etc/lsb-release;
+        sudo $PYTHON_EXECUTABLE -m pip install --upgrade pip;
+        sudo $PYTHON_EXECUTABLE -m pip install --upgrade cython3;
     fi
   - |
     if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$PYTHON_VERSION" = "2.7" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ matrix:
             - g++-6
             - gfortran-6
             - libpython3.5-dev
-            - cython3
             - python3-numpy
             - python3-pip
       env: CC='gcc-6' CXX='g++-6' FC='gfortran-6' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5' COVERAGE='ON'
@@ -30,7 +29,6 @@ matrix:
             - g++-7
             - gfortran-6
             - libpython3.5-dev
-            - cython3
             - python3-numpy
             - python3-pip
       env: CC='clang-3.6' CXX='clang++-3.6' FC='gfortran-6' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5'
@@ -48,7 +46,6 @@ matrix:
             - g++-7
             - gfortran-6
             - libpython3.5-dev
-            - cython3
             - python3-numpy
             - python3-pip
       env: CC='clang-4.0' CXX='clang++-4.0' FC='gfortran-6' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5'
@@ -64,7 +61,6 @@ matrix:
             - g++-4.4
             - gfortran-4.4
             - libpython3.5-dev
-            - cython3
             - python3-numpy
             - python3-pip
       env: CC='gcc-4.4' CXX='g++-4.4' FC='gfortran-4.4' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5'
@@ -80,7 +76,6 @@ matrix:
             - g++-4.7
             - gfortran-4.7
             - libpython3.5-dev
-            - cython3
             - python3-numpy
             - python3-pip
       env: CC='gcc-4.7' CXX='g++-4.7' FC='gfortran-4.7' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5'
@@ -96,7 +91,6 @@ matrix:
             - g++-4.8
             - gfortran-4.8
             - libpython3.5-dev
-            - cython3
             - python3-numpy
             - python3-pip
       env: CC='gcc-4.8' CXX='g++-4.8' FC='gfortran-4.8' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5'
@@ -112,7 +106,6 @@ matrix:
             - g++-4.9
             - gfortran-4.9
             - libpython3.5-dev
-            - cython3
             - python3-numpy
             - python3-pip
       env: CC='gcc-4.9' CXX='g++-4.9' FC='gfortran-4.9' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5'
@@ -155,7 +148,6 @@ matrix:
             - g++-6
             - gfortran-6
             - libpython3.5-dev
-            - cython3
             - python3-numpy
             - python3-pip
       env: CC='gcc-6' CXX='g++-6' FC='gfortran-6' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5' C_STANDARD='90'
@@ -171,7 +163,6 @@ matrix:
             - g++-6
             - gfortran-6
             - libpython3.5-dev
-            - cython3
             - python3-numpy
             - python3-pip
       env: CC='gcc-6' CXX='g++-6' FC='gfortran-6' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5' C_STANDARD='11'
@@ -187,7 +178,6 @@ matrix:
             - g++-6
             - gfortran-6
             - libpython3.5-dev
-            - cython3
             - python3-numpy
             - python3-pip
       env: CC='gcc-6' CXX='g++-6' FC='gfortran-6' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5' CXX_STANDARD='11'
@@ -203,7 +193,6 @@ matrix:
             - g++-6
             - gfortran-6
             - libpython3.5
-            - cython3
             - python3-numpy
             - python3-pip
       env: CC='gcc-6' CXX='g++-6' FC='gfortran-6' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5' CXX_STANDARD='14'
@@ -219,7 +208,6 @@ matrix:
             - g++-6
             - gfortran-6
             - libpython3.5
-            - cython3
             - python3-numpy
             - python3-pip
       env: CC='gcc-6' CXX='g++-6' FC='gfortran-6' FORTRAN_STANDARD='2008' PYTHON_VERSION='3.5'
@@ -235,7 +223,6 @@ matrix:
             - g++-7
             - gfortran-7
             - libpython3.5
-            - cython3
             - python3-numpy
             - python3-pip
       env: CC='gcc-7' CXX='g++-7' FC='gfortran-7' FORTRAN_STANDARD='2008' PYTHON_VERSION='3.5'

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
             - libpython3.5-dev
             - cython3
             - python3-numpy
-            - python-pip
+            - python3-pip
       env: CC='gcc-6' CXX='g++-6' FC='gfortran-6' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5' COVERAGE='ON'
 
     - os: linux
@@ -32,7 +32,7 @@ matrix:
             - libpython3.5-dev
             - cython3
             - python3-numpy
-            - python-pip
+            - python3-pip
       env: CC='clang-3.6' CXX='clang++-3.6' FC='gfortran-6' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5'
 
     - os: linux
@@ -50,7 +50,7 @@ matrix:
             - libpython3.5-dev
             - cython3
             - python3-numpy
-            - python-pip
+            - python3-pip
       env: CC='clang-4.0' CXX='clang++-4.0' FC='gfortran-6' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5'
 
     - os: linux
@@ -66,7 +66,7 @@ matrix:
             - libpython3.5-dev
             - cython3
             - python3-numpy
-            - python-pip
+            - python3-pip
       env: CC='gcc-4.4' CXX='g++-4.4' FC='gfortran-4.4' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5'
 
     - os: linux
@@ -82,7 +82,7 @@ matrix:
             - libpython3.5-dev
             - cython3
             - python3-numpy
-            - python-pip
+            - python3-pip
       env: CC='gcc-4.7' CXX='g++-4.7' FC='gfortran-4.7' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5'
 
     - os: linux
@@ -98,7 +98,7 @@ matrix:
             - libpython3.5-dev
             - cython3
             - python3-numpy
-            - python-pip
+            - python3-pip
       env: CC='gcc-4.8' CXX='g++-4.8' FC='gfortran-4.8' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5'
 
     - os: linux
@@ -114,7 +114,7 @@ matrix:
             - libpython3.5-dev
             - cython3
             - python3-numpy
-            - python-pip
+            - python3-pip
       env: CC='gcc-4.9' CXX='g++-4.9' FC='gfortran-4.9' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5'
 
     - os: linux
@@ -142,7 +142,6 @@ matrix:
             - g++-6
             - gfortran-6
             - libpython2.7
-            - python-pip
       env: CC='gcc-6' CXX='g++-6' FC='gfortran-6' FORTRAN_STANDARD='2003' PYTHON_VERSION='2.7'
 
     - os: linux
@@ -158,7 +157,7 @@ matrix:
             - libpython3.5-dev
             - cython3
             - python3-numpy
-            - python-pip
+            - python3-pip
       env: CC='gcc-6' CXX='g++-6' FC='gfortran-6' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5' C_STANDARD='90'
 
     - os: linux
@@ -174,7 +173,7 @@ matrix:
             - libpython3.5-dev
             - cython3
             - python3-numpy
-            - python-pip
+            - python3-pip
       env: CC='gcc-6' CXX='g++-6' FC='gfortran-6' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5' C_STANDARD='11'
 
     - os: linux
@@ -190,7 +189,7 @@ matrix:
             - libpython3.5-dev
             - cython3
             - python3-numpy
-            - python-pip
+            - python3-pip
       env: CC='gcc-6' CXX='g++-6' FC='gfortran-6' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5' CXX_STANDARD='11'
 
     - os: linux
@@ -206,7 +205,7 @@ matrix:
             - libpython3.5
             - cython3
             - python3-numpy
-            - python-pip
+            - python3-pip
       env: CC='gcc-6' CXX='g++-6' FC='gfortran-6' FORTRAN_STANDARD='2003' PYTHON_VERSION='3.5' CXX_STANDARD='14'
 
     - os: linux
@@ -222,7 +221,7 @@ matrix:
             - libpython3.5
             - cython3
             - python3-numpy
-            - python-pip
+            - python3-pip
       env: CC='gcc-6' CXX='g++-6' FC='gfortran-6' FORTRAN_STANDARD='2008' PYTHON_VERSION='3.5'
 
     - os: linux
@@ -238,7 +237,7 @@ matrix:
             - libpython3.5
             - cython3
             - python3-numpy
-            - python-pip
+            - python3-pip
       env: CC='gcc-7' CXX='g++-7' FC='gfortran-7' FORTRAN_STANDARD='2008' PYTHON_VERSION='3.5'
 
     - os: osx
@@ -287,22 +286,18 @@ script:
     if [ "$TRAVIS_OS_NAME" = "linux" ]; then
         export PYTHON_EXECUTABLE=/usr/bin/python$PYTHON_VERSION;
         source /etc/lsb-release;
-        sudo $PYTHON_EXECUTABLE -m pip install --upgrade pip;
-        sudo $PYTHON_EXECUTABLE -m pip install --upgrade cython3;
     fi
   - |
     if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$PYTHON_VERSION" = "2.7" ]; then
         export PYTHON_INCLUDE_DIR=/usr/include/python2.7;
         export PYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython2.7.so;
-        sudo $PYTHON_EXECUTABLE -m pip install --upgrade pip;
-        sudo $PYTHON_EXECUTABLE -m pip install --upgrade cython3;
     fi
   - |
     if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$PYTHON_VERSION" = "3.5" ]; then
         export PYTHON_INCLUDE_DIR=/usr/include/python3.5m;
         export PYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.5m.so;
-        sudo $PYTHON_EXECUTABLE -m pip install --upgrade pip;
-        sudo $PYTHON_EXECUTABLE -m pip install --upgrade cython3;
+        sudo $PYTHON_EXECUTABLE -m pip3 install --upgrade pip3;
+        sudo $PYTHON_EXECUTABLE -m pip3 install --upgrade cython3;
     fi
   - |
     if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$DISTRIB_CODENAME" = "trusty" ] && [ "$PYTHON_VERSION" = "2.7" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -296,7 +296,6 @@ script:
     if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$PYTHON_VERSION" = "3.5" ]; then
         export PYTHON_INCLUDE_DIR=/usr/include/python3.5m;
         export PYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.5m.so;
-        sudo $PYTHON_EXECUTABLE -m pip3 install --upgrade pip3;
         sudo $PYTHON_EXECUTABLE -m pip3 install --upgrade cython3;
     fi
   - |

--- a/python/zfpy.pyx
+++ b/python/zfpy.pyx
@@ -260,7 +260,7 @@ cpdef np.ndarray _decompress(
         raise ValueError("Cannot decompress in-place")
     _validate_4d_list(shape, "shape")
 
-    cdef const char* comp_data_pointer = <const char*>&compressed_data[0]
+    cdef const void* comp_data_pointer = <const void*>&compressed_data[0]
     cdef zfp_field* field = zfp_field_alloc()
     cdef bitstream* bstream = stream_open(
         <void *>comp_data_pointer,
@@ -329,12 +329,12 @@ cpdef np.ndarray _decompress(
     return output
 
 cpdef np.ndarray decompress_numpy(
-     const uint8_t[::1] compressed_data,
+    const uint8_t[::1] compressed_data,
 ):
     if compressed_data is None:
         raise TypeError("compressed_data cannot be None")
 
-    cdef const char* comp_data_pointer = <const char *>&compressed_data[0]
+    cdef const void* comp_data_pointer = <const void *>&compressed_data[0]
     cdef zfp_field* field = zfp_field_alloc()
     cdef bitstream* bstream = stream_open(
         <void *>comp_data_pointer,

--- a/python/zfpy.pyx
+++ b/python/zfpy.pyx
@@ -261,7 +261,7 @@ cpdef np.ndarray _decompress(
         raise ValueError("Cannot decompress in-place")
     _validate_4d_list(shape, "shape")
 
-    cdef char* comp_data_pointer = <char*>&compressed_data[0]
+    cdef const char* comp_data_pointer = <const char*>&compressed_data[0]
     cdef zfp_field* field = zfp_field_alloc()
     cdef bitstream* bstream = stream_open(
         comp_data_pointer,
@@ -335,7 +335,7 @@ cpdef np.ndarray decompress_numpy(
     if compressed_data is None:
         raise TypeError("compressed_data cannot be None")
 
-    cdef char* comp_data_pointer = <char *>&compressed_data[0]
+    cdef const char* comp_data_pointer = <const char *>&compressed_data[0]
     cdef zfp_field* field = zfp_field_alloc()
     cdef bitstream* bstream = stream_open(
         comp_data_pointer,

--- a/python/zfpy.pyx
+++ b/python/zfpy.pyx
@@ -264,7 +264,7 @@ cpdef np.ndarray _decompress(
     cdef const char* comp_data_pointer = <const char*>&compressed_data[0]
     cdef zfp_field* field = zfp_field_alloc()
     cdef bitstream* bstream = stream_open(
-        <char*>comp_data_pointer,
+        <void *>comp_data_pointer,
         len(compressed_data)
     )
     cdef zfp_stream* stream = zfp_stream_open(bstream)
@@ -330,7 +330,7 @@ cpdef np.ndarray _decompress(
     return output
 
 cpdef np.ndarray decompress_numpy(
-     uint8_t[::1] compressed_data,
+     const uint8_t[::1] compressed_data,
 ):
     if compressed_data is None:
         raise TypeError("compressed_data cannot be None")
@@ -338,7 +338,7 @@ cpdef np.ndarray decompress_numpy(
     cdef const char* comp_data_pointer = <const char *>&compressed_data[0]
     cdef zfp_field* field = zfp_field_alloc()
     cdef bitstream* bstream = stream_open(
-        <char *>comp_data_pointer,
+        <void *>comp_data_pointer,
         len(compressed_data)
     )
     cdef zfp_stream* stream = zfp_stream_open(bstream)

--- a/python/zfpy.pyx
+++ b/python/zfpy.pyx
@@ -254,7 +254,6 @@ cpdef np.ndarray _decompress(
     double rate = -1,
     int precision = -1,
 ):
-    print(cython.__version__)
     if compressed_data is None:
         raise TypeError("compressed_data cannot be None")
     if compressed_data is out:

--- a/python/zfpy.pyx
+++ b/python/zfpy.pyx
@@ -254,7 +254,7 @@ cpdef np.ndarray _decompress(
     double rate = -1,
     int precision = -1,
 ):
-
+    print(cython.__version__)
     if compressed_data is None:
         raise TypeError("compressed_data cannot be None")
     if compressed_data is out:

--- a/python/zfpy.pyx
+++ b/python/zfpy.pyx
@@ -246,7 +246,7 @@ cdef _validate_4d_list(in_list, list_name):
         )
 
 cpdef np.ndarray _decompress(
-    const uint8_t[::1] compressed_data,
+    uint8_t[::1] compressed_data,
     zfp_type ztype,
     shape,
     out=None,
@@ -261,7 +261,7 @@ cpdef np.ndarray _decompress(
         raise ValueError("Cannot decompress in-place")
     _validate_4d_list(shape, "shape")
 
-    cdef const char* comp_data_pointer = <const char*>&compressed_data[0]
+    cdef char* comp_data_pointer = <char*>&compressed_data[0]
     cdef zfp_field* field = zfp_field_alloc()
     cdef bitstream* bstream = stream_open(
         comp_data_pointer,
@@ -330,12 +330,12 @@ cpdef np.ndarray _decompress(
     return output
 
 cpdef np.ndarray decompress_numpy(
-    const uint8_t[::1] compressed_data,
+    uint8_t[::1] compressed_data,
 ):
     if compressed_data is None:
         raise TypeError("compressed_data cannot be None")
 
-    cdef const char* comp_data_pointer = <const char *>&compressed_data[0]
+    cdef char* comp_data_pointer = <char *>&compressed_data[0]
     cdef zfp_field* field = zfp_field_alloc()
     cdef bitstream* bstream = stream_open(
         comp_data_pointer,

--- a/python/zfpy.pyx
+++ b/python/zfpy.pyx
@@ -5,6 +5,7 @@ import cython
 from libc.stdlib cimport malloc, free
 from cython cimport view
 from cpython cimport array
+from libc.stdint cimport uint8_t
 import array
 
 import itertools
@@ -245,7 +246,7 @@ cdef _validate_4d_list(in_list, list_name):
         )
 
 cpdef np.ndarray _decompress(
-    bytes compressed_data,
+    const uint8_t[::1] compressed_data,
     zfp_type ztype,
     shape,
     out=None,
@@ -260,7 +261,7 @@ cpdef np.ndarray _decompress(
         raise ValueError("Cannot decompress in-place")
     _validate_4d_list(shape, "shape")
 
-    cdef char* comp_data_pointer = compressed_data
+    cdef char* comp_data_pointer = <char*>&compressed_data[0]
     cdef zfp_field* field = zfp_field_alloc()
     cdef bitstream* bstream = stream_open(
         comp_data_pointer,
@@ -329,12 +330,12 @@ cpdef np.ndarray _decompress(
     return output
 
 cpdef np.ndarray decompress_numpy(
-    bytes compressed_data,
+    const uint8_t[::1] compressed_data,
 ):
     if compressed_data is None:
         raise TypeError("compressed_data cannot be None")
 
-    cdef char* comp_data_pointer = compressed_data
+    cdef char* comp_data_pointer = <char *>&compressed_data[0]
     cdef zfp_field* field = zfp_field_alloc()
     cdef bitstream* bstream = stream_open(
         comp_data_pointer,

--- a/python/zfpy.pyx
+++ b/python/zfpy.pyx
@@ -246,7 +246,7 @@ cdef _validate_4d_list(in_list, list_name):
         )
 
 cpdef np.ndarray _decompress(
-    uint8_t[::1] compressed_data,
+    const uint8_t[::1] compressed_data,
     zfp_type ztype,
     shape,
     out=None,
@@ -261,10 +261,10 @@ cpdef np.ndarray _decompress(
         raise ValueError("Cannot decompress in-place")
     _validate_4d_list(shape, "shape")
 
-    cdef char* comp_data_pointer = <char*>&compressed_data[0]
+    cdef const char* comp_data_pointer = <const char*>&compressed_data[0]
     cdef zfp_field* field = zfp_field_alloc()
     cdef bitstream* bstream = stream_open(
-        comp_data_pointer,
+        <char*>comp_data_pointer,
         len(compressed_data)
     )
     cdef zfp_stream* stream = zfp_stream_open(bstream)
@@ -330,15 +330,15 @@ cpdef np.ndarray _decompress(
     return output
 
 cpdef np.ndarray decompress_numpy(
-    uint8_t[::1] compressed_data,
+     uint8_t[::1] compressed_data,
 ):
     if compressed_data is None:
         raise TypeError("compressed_data cannot be None")
 
-    cdef char* comp_data_pointer = <char *>&compressed_data[0]
+    cdef const char* comp_data_pointer = <const char *>&compressed_data[0]
     cdef zfp_field* field = zfp_field_alloc()
     cdef bitstream* bstream = stream_open(
-        comp_data_pointer,
+        <char *>comp_data_pointer,
         len(compressed_data)
     )
     cdef zfp_stream* stream = zfp_stream_open(bstream)

--- a/tests/python/test_numpy.py
+++ b/tests/python/test_numpy.py
@@ -59,12 +59,16 @@ class TestNumpy(unittest.TestCase):
                 compress_param_num
             ),
         }
-        compressed_array = zfpy.compress_numpy(
+        compressed_array_t = zfpy.compress_numpy(
             random_array,
             write_header=False,
             **compression_kwargs
         )
-
+        if isinstance(compressed_array_t, np.ndarray):
+            compressed_array = compressed_array_t
+        else:
+            mem = memoryview(compressed_array_t)
+            compressed_array = np.array(mem, copy=False)
         # Decompression using the "advanced" interface which enforces no header,
         # and the user must provide all the metadata
         decompressed_array = np.empty_like(random_array)
@@ -177,11 +181,16 @@ class TestNumpy(unittest.TestCase):
                             # Decompression using the "public" interface
                             # requires a header, so re-compress with the header
                             # included in the stream
-                            compressed_array = zfpy.compress_numpy(
+                            compressed_array_t = zfpy.compress_numpy(
                                 random_array,
                                 write_header=True,
                                 **compression_kwargs
                             )
+                            if isinstance(compressed_array_t, np.ndarray):
+                                compressed_array = compressed_array_t
+                            else:
+                                mem = memoryview(compressed_array_t)
+                                compressed_array = np.array(mem, copy=False)
                             decompressed_array = zfpy.decompress_numpy(
                                 compressed_array,
                             )

--- a/tests/python/test_numpy.py
+++ b/tests/python/test_numpy.py
@@ -59,16 +59,13 @@ class TestNumpy(unittest.TestCase):
                 compress_param_num
             ),
         }
-        compressed_array_t = zfpy.compress_numpy(
+        compressed_array_tmp = zfpy.compress_numpy(
             random_array,
             write_header=False,
             **compression_kwargs
         )
-        if isinstance(compressed_array_t, np.ndarray):
-            compressed_array = compressed_array_t
-        else:
-            mem = memoryview(compressed_array_t)
-            compressed_array = np.array(mem, copy=False)
+        mem = memoryview(compressed_array_tmp)
+        compressed_array = np.array(mem, copy=False)
         # Decompression using the "advanced" interface which enforces no header,
         # and the user must provide all the metadata
         decompressed_array = np.empty_like(random_array)
@@ -181,16 +178,13 @@ class TestNumpy(unittest.TestCase):
                             # Decompression using the "public" interface
                             # requires a header, so re-compress with the header
                             # included in the stream
-                            compressed_array_t = zfpy.compress_numpy(
+                            compressed_array_tmp = zfpy.compress_numpy(
                                 random_array,
                                 write_header=True,
                                 **compression_kwargs
                             )
-                            if isinstance(compressed_array_t, np.ndarray):
-                                compressed_array = compressed_array_t
-                            else:
-                                mem = memoryview(compressed_array_t)
-                                compressed_array = np.array(mem, copy=False)
+                            mem = memoryview(compressed_array_tmp)
+                            compressed_array = np.array(mem, copy=False)
                             decompressed_array = zfpy.decompress_numpy(
                                 compressed_array,
                             )

--- a/travis.sh
+++ b/travis.sh
@@ -45,7 +45,7 @@ else
   BUILD_FLAGS="$BUILD_FLAGS -DBUILD_OPENMP=OFF"
   BUILD_FLAGS="$BUILD_FLAGS -DBUILD_CUDA=OFF"
   run_all "$BUILD_FLAGS"
-
+  python -m cython --version
   rm -rf ./* ;
 
   # if OpenMP available, start a 2nd build with it

--- a/travis.sh
+++ b/travis.sh
@@ -45,7 +45,7 @@ else
   BUILD_FLAGS="$BUILD_FLAGS -DBUILD_OPENMP=OFF"
   BUILD_FLAGS="$BUILD_FLAGS -DBUILD_CUDA=OFF"
   run_all "$BUILD_FLAGS"
-  python -m cython --version
+
   rm -rf ./* ;
 
   # if OpenMP available, start a 2nd build with it


### PR DESCRIPTION
I replaced type bytes with const uint8_t[::1], this way the compressed stream can be checked by ensure_ndarray of numcodecs, and also it prevents numpy array tobytes procedures. I tested with ensure_ndarray, and the default zfp tests.