### PR TITLE
Avoid importing unused cpython array for compatibility with pypy

### DIFF
--- a/python/zfpy.pyx
+++ b/python/zfpy.pyx
@@ -4,9 +4,7 @@ import functools
 import cython
 from libc.stdlib cimport malloc, free
 from cython cimport view
-from cpython cimport array
 from libc.stdint cimport uint8_t
-import array
 
 import itertools
 if sys.version_info[0] == 2:


### PR DESCRIPTION
Do you have a changelog you want me to add a note in?

A good explanation as to why this is important
https://github.com/h5py/h5py/issues/1514
