### PR TITLE
CUDA variable bitrate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,12 @@ if(ZFP_WITH_CUDA)
   if(${CUDA_VERSION_MAJOR} LESS 7)
     message(FATAL_ERROR "zfp requires at least CUDA 7.0.")
   endif()
+  if(${CUDA_VERSION_MAJOR} LESS 11)
+    # CUB is part of CUDA since CUDA 11
+    # Todo: get CUB from https://github.com/NVIDIA/cub.git
+    message(FATAL_ERROR "zfp requires at least CUDA 7.0.")
+  endif()
+  # set (CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -G -g")
 endif()
 
 if(NOT (ZFP_BIT_STREAM_WORD_SIZE EQUAL 64))

--- a/include/zfp.h
+++ b/include/zfp.h
@@ -740,6 +740,9 @@ void zfp_demote_int32_to_uint8(uint8* oblock, const int32* iblock, uint dims);
 void zfp_demote_int32_to_int16(int16* oblock, const int32* iblock, uint dims);
 void zfp_demote_int32_to_uint16(uint16* oblock, const int32* iblock, uint dims);
 
+/* Conservative size (in bits) of a single compressed block */
+uint zfp_block_maxbits(const zfp_stream* zfp, const zfp_field* field);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zfp.h
+++ b/include/zfp.h
@@ -422,6 +422,10 @@ zfp_field_size_bytes(
   const zfp_field* field /* field metadata */
 );
 
+/* number of ZFP blocks */
+size_t
+zfp_field_num_blocks (const zfp_field* field);
+
 /* field strides per dimension */
 zfp_bool                  /* true if array is not contiguous */
 zfp_field_stride(

--- a/src/cuda_zfp/cuZFP.cu
+++ b/src/cuda_zfp/cuZFP.cu
@@ -1,5 +1,7 @@
 #include <assert.h>
 
+#include <cub/cub.cuh>
+
 #include "cuZFP.h"
 
 #include "encode1.cuh"
@@ -10,6 +12,8 @@
 #include "decode2.cuh"
 #include "decode3.cuh"
 
+#include "variable.cuh"
+
 #include "ErrorCheck.h"
 
 #include "pointers.cuh"
@@ -17,16 +21,16 @@
 #include <iostream>
 #include <assert.h>
 
-// we need to know about bitstream, but we don't 
+// we need to know about bitstream, but we don't
 // want duplicate symbols.
 #ifndef inline_
-  #define inline_ inline
+#define inline_ inline
 #endif
 
 #include "../inline/bitstream.c"
-namespace internal 
-{ 
-  
+namespace internal
+{
+
 bool is_contigous3d(const uint dims[3], const int3 &stride, long long int &offset)
 {
   typedef long long int int64;
@@ -35,13 +39,13 @@ bool is_contigous3d(const uint dims[3], const int3 &stride, long long int &offse
   idims[1] = dims[1];
   idims[2] = dims[2];
 
-  int64 imin = std::min(stride.x,0) * (idims[0] - 1) + 
-               std::min(stride.y,0) * (idims[1] - 1) + 
-               std::min(stride.z,0) * (idims[2] - 1);
+  int64 imin = std::min(stride.x,0) * (idims[0] - 1) +
+                std::min(stride.y,0) * (idims[1] - 1) +
+                std::min(stride.z,0) * (idims[2] - 1);
 
-  int64 imax = std::max(stride.x,0) * (idims[0] - 1) + 
-               std::max(stride.y,0) * (idims[1] - 1) + 
-               std::max(stride.z,0) * (idims[2] - 1);
+  int64 imax = std::max(stride.x,0) * (idims[0] - 1) +
+                std::max(stride.y,0) * (idims[1] - 1) +
+                std::max(stride.z,0) * (idims[2] - 1);
   offset = imin;
   int64 ns = idims[0] * idims[1] * idims[2];
 
@@ -55,11 +59,11 @@ bool is_contigous2d(const uint dims[3], const int3 &stride, long long int &offse
   idims[0] = dims[0];
   idims[1] = dims[1];
 
-  int64 imin = std::min(stride.x,0) * (idims[0] - 1) + 
-               std::min(stride.y,0) * (idims[1] - 1);
+  int64 imin = std::min(stride.x,0) * (idims[0] - 1) +
+                std::min(stride.y,0) * (idims[1] - 1);
 
-  int64  imax = std::max(stride.x,0) * (idims[0] - 1) + 
-                std::max(stride.y,0) * (idims[1] - 1); 
+  int64  imax = std::max(stride.x,0) * (idims[0] - 1) +
+                std::max(stride.y,0) * (idims[1] - 1);
 
   offset = imin;
   return (imax - imin + 1) == (idims[0] * idims[1]);
@@ -75,18 +79,18 @@ bool is_contigous1d(uint dim, const int &stride, long long int &offset)
 bool is_contigous(const uint dims[3], const int3 &stride, long long int &offset)
 {
   int d = 0;
-  
+
   if(dims[0] != 0) d++;
   if(dims[1] != 0) d++;
   if(dims[2] != 0) d++;
 
-  if(d == 3)
+    if(d == 3)
   {
     return is_contigous3d(dims, stride, offset);
   }
   else if(d == 2)
   {
-   return is_contigous2d(dims, stride, offset);
+  return is_contigous2d(dims, stride, offset);
   }
   else
   {
@@ -97,8 +101,9 @@ bool is_contigous(const uint dims[3], const int3 &stride, long long int &offset)
 //
 // encode expects device pointers
 //
-template<typename T>
-size_t encode(uint dims[3], int3 stride, int bits_per_block, T *d_data, Word *d_stream)
+template <typename T, bool variable_rate>
+size_t encode(uint dims[3], int3 stride, int minbits, int maxbits,
+              int maxprec, int minexp, T *d_data, Word *d_stream, ushort *d_bitlengths)
 {
 
   int d = 0;
@@ -118,29 +123,32 @@ size_t encode(uint dims[3], int3 stride, int bits_per_block, T *d_data, Word *d_
   {
     int dim = dims[0];
     int sx = stride.x;
-    stream_size = cuZFP::encode1<T>(dim, sx, d_data, d_stream, bits_per_block); 
+    stream_size = cuZFP::encode1<T, variable_rate>(dim, sx, d_data, d_stream, d_bitlengths,
+                                                    minbits, maxbits, maxprec, minexp);
   }
   else if(d == 2)
   {
     uint2 ndims = make_uint2(dims[0], dims[1]);
     int2 s;
-    s.x = stride.x; 
-    s.y = stride.y; 
-    stream_size = cuZFP::encode2<T>(ndims, s, d_data, d_stream, bits_per_block); 
+    s.x = stride.x;
+    s.y = stride.y;
+    stream_size = cuZFP::encode2<T, variable_rate>(ndims, s, d_data, d_stream, d_bitlengths,
+                                                    minbits, maxbits, maxprec, minexp);
   }
   else if(d == 3)
   {
     int3 s;
-    s.x = stride.x; 
-    s.y = stride.y; 
-    s.z = stride.z; 
+    s.x = stride.x;
+    s.y = stride.y;
+    s.z = stride.z;
     uint3 ndims = make_uint3(dims[0], dims[1], dims[2]);
-    stream_size = cuZFP::encode<T>(ndims, s, d_data, d_stream, bits_per_block); 
+    stream_size = cuZFP::encode<T, variable_rate>(ndims, s, d_data, d_stream, d_bitlengths,
+                                                  minbits, maxbits, maxprec, minexp);
   }
 
   errors.chk("Encode");
-  
-  return stream_size; 
+
+  return stream_size;
 }
 
 template<typename T>
@@ -164,18 +172,18 @@ size_t decode(uint ndims[3], int3 stride, int bits_per_block, Word *stream, T *o
     uint3 dims = make_uint3(ndims[0], ndims[1], ndims[2]);
 
     int3 s;
-    s.x = stride.x; 
-    s.y = stride.y; 
-    s.z = stride.z; 
+    s.x = stride.x;
+    s.y = stride.y;
+    s.z = stride.z;
 
-    stream_bytes = cuZFP::decode3<T>(dims, s, stream, out, bits_per_block); 
+    stream_bytes = cuZFP::decode3<T>(dims, s, stream, out, bits_per_block);
   }
   else if(d == 1)
   {
     uint dim = ndims[0];
     int sx = stride.x;
 
-    stream_bytes = cuZFP::decode1<T>(dim, sx, stream, out, bits_per_block); 
+    stream_bytes = cuZFP::decode1<T>(dim, sx, stream, out, bits_per_block);
 
   }
   else if(d == 2)
@@ -185,13 +193,13 @@ size_t decode(uint ndims[3], int3 stride, int bits_per_block, Word *stream, T *o
     dims.y = ndims[1];
 
     int2 s;
-    s.x = stride.x; 
-    s.y = stride.y; 
+    s.x = stride.x;
+    s.y = stride.y;
 
-    stream_bytes = cuZFP::decode2<T>(dims, s, stream, out, bits_per_block); 
+    stream_bytes = cuZFP::decode2<T>(dims, s, stream, out, bits_per_block);
   }
   else std::cerr<<" d ==  "<<d<<" not implemented\n";
- 
+
   return stream_bytes;
 }
 
@@ -207,7 +215,11 @@ Word *setup_device_stream_compress(zfp_stream *stream,const zfp_field *field)
 
   Word *d_stream = NULL;
   size_t max_size = zfp_stream_maximum_size(stream, field);
+#if (CUDART_VERSION >= 11020)
+  cudaMallocAsync(&d_stream, max_size, 0);
+#else
   cudaMalloc(&d_stream, max_size);
+#endif
   return d_stream;
 }
 
@@ -224,7 +236,11 @@ Word *setup_device_stream_decompress(zfp_stream *stream,const zfp_field *field)
   Word *d_stream = NULL;
   //TODO: change maximum_size to compressed stream size
   size_t size = zfp_stream_maximum_size(stream, field);
+#if (CUDART_VERSION >= 11020)
+  cudaMallocAsync(&d_stream, size, 0);
+#else
   cudaMalloc(&d_stream, size);
+#endif
   cudaMemcpy(d_stream, stream->stream->begin, size, cudaMemcpyHostToDevice);
   return d_stream;
 }
@@ -264,7 +280,7 @@ void *setup_device_field_compress(const zfp_field *field, const int3 &stride, lo
     offset = 0;
     return field->data;
   }
-  
+
   uint dims[3];
   dims[0] = field->nx;
   dims[1] = field->ny;
@@ -282,14 +298,18 @@ void *setup_device_field_compress(const zfp_field *field, const int3 &stride, lo
   }
 
   bool contig = internal::is_contigous(dims, stride, offset);
-  
+
   void * host_ptr = offset_void(field->type, field->data, offset);;
 
   void *d_data = NULL;
   if(contig)
   {
     size_t field_bytes = type_size * field_size;
+#if (CUDART_VERSION >= 11020)
+    cudaMallocAsync(&d_data, field_bytes, 0);
+#else
     cudaMalloc(&d_data, field_bytes);
+#endif
 
     cudaMemcpy(d_data, host_ptr, field_bytes, cudaMemcpyHostToDevice);
   }
@@ -328,9 +348,98 @@ void *setup_device_field_decompress(const zfp_field *field, const int3 &stride, 
   if(contig)
   {
     size_t field_bytes = type_size * field_size;
+#if (CUDART_VERSION >= 11020)
+    cudaMallocAsync(&d_data, field_bytes, 0);
+#else
     cudaMalloc(&d_data, field_bytes);
+#endif
   }
   return offset_void(field->type, d_data, -offset);
+}
+
+ushort *setup_device_nbits_compress(zfp_stream *stream, const zfp_field *field, int variable_rate)
+{
+  if (!variable_rate)
+    return NULL;
+
+  bool device_mem = cuZFP::is_gpu_ptr(stream->stream->bitlengths);
+  if (device_mem)
+    return (ushort *)stream->stream->bitlengths;
+
+  ushort *d_bitlengths = NULL;
+  size_t size = zfp_field_num_blocks(field) * sizeof(ushort);
+#if (CUDART_VERSION >= 11020)
+  cudaMallocAsync(&d_bitlengths, size, 0);
+#else
+  cudaMalloc(&d_bitlengths, size);
+#endif
+  return d_bitlengths;
+}
+
+ushort *setup_device_nbits_decompress(zfp_stream *stream, const zfp_field *field, int variable_rate)
+{
+  if (!variable_rate)
+    return NULL;
+
+  if (cuZFP::is_gpu_ptr(stream->stream->bitlengths))
+    return stream->stream->bitlengths;
+
+  ushort *d_bitlengths = NULL;
+  size_t size = zfp_field_num_blocks(field) * sizeof(ushort);
+#if (CUDART_VERSION >= 11020)
+  cudaMallocAsync(&d_bitlengths, size, 0);
+#else
+  cudaMalloc(&d_bitlengths, size);
+#endif
+  cudaMemcpy(d_bitlengths, stream->stream->bitlengths, size, cudaMemcpyHostToDevice);
+  return d_bitlengths;
+}
+
+void cleanup_device_nbits(zfp_stream *stream, const zfp_field *field,
+                          ushort *d_bitlengths, int variable_rate, int copy)
+{
+  if (!variable_rate)
+    return;
+
+  if (cuZFP::is_gpu_ptr(stream->stream->bitlengths))
+    return;
+
+  size_t size = zfp_field_num_blocks(field) * sizeof(ushort);
+  if (copy)
+    cudaMemcpy(stream->stream->bitlengths, d_bitlengths, size, cudaMemcpyDeviceToHost);
+
+#if (CUDART_VERSION >= 11020)
+  cudaFreeAsync(d_bitlengths, 0);
+#else
+  cudaFree(d_bitlengths);
+#endif
+}
+
+void setup_device_chunking(int *chunk_size, unsigned long long **d_offsets, size_t *lcubtemp,
+                            void **d_cubtemp, int num_sm, int variable_rate)
+{
+  if (!variable_rate)
+    return;
+
+  // TODO : Error handling for CUDA malloc and CUB?
+  // Assuming 1 thread = 1 ZFP block,
+  // launching 1024 threads per SM should give a decent occupancy
+  *chunk_size = num_sm * 1024;
+  size_t size = (*chunk_size + 1) * sizeof(unsigned long long);
+#if (CUDART_VERSION >= 11020)
+  cudaMallocAsync(d_offsets, size, 0);
+#else
+  cudaMalloc(d_offsets, size);
+#endif
+  // Using CUB for the prefix sum. CUB needs a bit of temp memory too
+  size_t tempsize;
+  cub::DeviceScan::InclusiveSum(nullptr, tempsize, *d_offsets, *d_offsets, *chunk_size + 1);
+  *lcubtemp = tempsize;
+#if (CUDART_VERSION >= 11020)
+  cudaMallocAsync(d_cubtemp, tempsize, 0);
+#else
+  cudaMalloc(d_cubtemp, tempsize);
+#endif
 }
 
 void cleanup_device_ptr(void *orig_ptr, void *d_ptr, size_t bytes, long long int offset, zfp_type type)
@@ -349,26 +458,30 @@ void cleanup_device_ptr(void *orig_ptr, void *d_ptr, size_t bytes, long long int
     cudaMemcpy(h_offset_ptr, d_offset_ptr, bytes, cudaMemcpyDeviceToHost);
   }
 
+#if (CUDART_VERSION >= 11020)
+  cudaFreeAsync(d_offset_ptr, 0);
+#else
   cudaFree(d_offset_ptr);
+#endif
 }
 
 } // namespace internal
 
 size_t
-cuda_compress(zfp_stream *stream, const zfp_field *field)
+cuda_compress(zfp_stream *stream, const zfp_field *field, int variable_rate)
 {
   uint dims[3];
   dims[0] = field->nx;
   dims[1] = field->ny;
   dims[2] = field->nz;
 
-  int3 stride;  
+  int3 stride;
   stride.x = field->sx ? field->sx : 1;
   stride.y = field->sy ? field->sy : field->nx;
   stride.z = field->sz ? field->sz : field->nx * field->ny;
-  
+
   size_t stream_bytes = 0;
-  long long int offset = 0; 
+  long long int offset = 0;
   void *d_data = internal::setup_device_field_compress(field, stride, offset);
 
   if(d_data == NULL)
@@ -377,51 +490,119 @@ cuda_compress(zfp_stream *stream, const zfp_field *field)
     return 0;
   }
 
+#if (CUDART_VERSION < 9000)
+  if (variable_rate)
+    return 0; // Variable rate requires CUDA >= 9
+#endif
+
+  int num_sm;
+  cudaDeviceGetAttribute(&num_sm, cudaDevAttrMultiProcessorCount, 0);
+
   Word *d_stream = internal::setup_device_stream_compress(stream, field);
+
+  ushort *d_bitlengths = internal::setup_device_nbits_compress(stream, field, variable_rate);
+
+  int chunk_size;
+  unsigned long long *d_offsets;
+  size_t lcubtemp;
+  void *d_cubtemp;
+  internal::setup_device_chunking(&chunk_size, &d_offsets, &lcubtemp, &d_cubtemp, num_sm, variable_rate);
+
+  uint buffer_maxbits = MIN (stream->maxbits, zfp_block_maxbits(stream, field));
 
   if(field->type == zfp_type_float)
   {
     float* data = (float*) d_data;
-    stream_bytes = internal::encode<float>(dims, stride, (int)stream->maxbits, data, d_stream);
+    if (variable_rate)
+      stream_bytes = internal::encode<float, true>(dims, stride, stream->minbits, (int)buffer_maxbits,
+                                                   stream->maxprec, stream->minexp, data, d_stream, d_bitlengths);
+    else
+      stream_bytes = internal::encode<float, false>(dims, stride, stream->minbits, (int)buffer_maxbits,
+                                                    stream->maxprec, stream->minexp, data, d_stream, d_bitlengths);
   }
   else if(field->type == zfp_type_double)
   {
     double* data = (double*) d_data;
-    stream_bytes = internal::encode<double>(dims, stride, (int)stream->maxbits, data, d_stream);
+    if (variable_rate)
+      stream_bytes = internal::encode<double, true>(dims, stride, stream->minbits, (int)buffer_maxbits,
+                                                    stream->maxprec, stream->minexp, data, d_stream, d_bitlengths);
+    else
+      stream_bytes = internal::encode<double, false>(dims, stride, stream->minbits, (int)buffer_maxbits,
+                                                     stream->maxprec, stream->minexp, data, d_stream, d_bitlengths);
   }
   else if(field->type == zfp_type_int32)
   {
     int * data = (int*) d_data;
-    stream_bytes = internal::encode<int>(dims, stride, (int)stream->maxbits, data, d_stream);
+    if (variable_rate)
+      stream_bytes = internal::encode<int, true>(dims, stride, stream->minbits, (int)buffer_maxbits,
+                                                 stream->maxprec, stream->minexp, data, d_stream, d_bitlengths);
+    else
+      stream_bytes = internal::encode<int, false>(dims, stride, stream->minbits, (int)buffer_maxbits,
+                                                  stream->maxprec, stream->minexp, data, d_stream, d_bitlengths);
   }
   else if(field->type == zfp_type_int64)
   {
     long long int * data = (long long int*) d_data;
-    stream_bytes = internal::encode<long long int>(dims, stride, (int)stream->maxbits, data, d_stream);
+    if (variable_rate)
+      stream_bytes = internal::encode<long long int, true>(dims, stride, stream->minbits, (int)buffer_maxbits,
+                                                           stream->maxprec, stream->minexp, data, d_stream, d_bitlengths);
+    else
+      stream_bytes = internal::encode<long long int, false>(dims, stride, stream->minbits, (int)buffer_maxbits,
+                                                            stream->maxprec, stream->minexp, data, d_stream, d_bitlengths);
+  }
+
+  if (variable_rate)
+  {
+    size_t blocks = zfp_field_num_blocks(field);
+    for (size_t i = 0; i < blocks; i += chunk_size)
+    {
+      int cur_blocks = i + chunk_size <= blocks ? chunk_size : (int)(blocks - i);
+      // Copy the 16-bit lengths in the offset array
+      cuZFP::copy_length_launch(d_bitlengths, d_offsets, i, cur_blocks);
+
+      // Prefix sum to turn length into offsets
+      cub::DeviceScan::InclusiveSum(d_cubtemp, lcubtemp, d_offsets, d_offsets, cur_blocks + 1);
+
+      // Compact the stream array in-place
+      cuZFP::chunk_process_launch((uint*)d_stream, d_offsets, i, cur_blocks, buffer_maxbits, num_sm);
+    }
+    // The total length in bits is now in the base of the prefix sum.
+    cudaMemcpy (&stream_bytes, d_offsets, sizeof (unsigned long long), cudaMemcpyDeviceToHost);
+    stream_bytes = (stream_bytes + 7) / 8;
   }
 
   internal::cleanup_device_ptr(stream->stream->begin, d_stream, stream_bytes, 0, field->type);
   internal::cleanup_device_ptr(field->data, d_data, 0, offset, field->type);
+  if (variable_rate)
+  {
+    if (stream->stream->bitlengths) // Saving the individual block lengths if a pointer exists
+    {
+      size_t size = zfp_field_num_blocks(field) * sizeof(ushort);
+      internal::cleanup_device_ptr(stream->stream->bitlengths, d_bitlengths, size, 0, zfp_type_none);
+    }
+    internal::cleanup_device_ptr(NULL, d_offsets, 0, 0, zfp_type_none);
+    internal::cleanup_device_ptr(NULL, d_cubtemp, 0, 0, zfp_type_none);
+  }
 
   // zfp wants to flush the stream.
   // set bits to wsize because we already did that.
-  size_t compressed_size = stream_bytes / sizeof(Word);
+  size_t compressed_size = (stream_bytes + sizeof(Word) - 1) / sizeof(Word);
   stream->stream->bits = wsize;
   // set stream pointer to end of stream
   stream->stream->ptr = stream->stream->begin + compressed_size;
 
   return stream_bytes;
 }
-  
-void 
+
+void
 cuda_decompress(zfp_stream *stream, zfp_field *field)
 {
   uint dims[3];
   dims[0] = field->nx;
   dims[1] = field->ny;
   dims[2] = field->nz;
-   
-  int3 stride;  
+
+  int3 stride;
   stride.x = field->sx ? field->sx : 1;
   stride.y = field->sy ? field->sy : field->nx;
   stride.z = field->sz ? field->sz : field->nx * field->ny;
@@ -429,7 +610,7 @@ cuda_decompress(zfp_stream *stream, zfp_field *field)
   size_t decoded_bytes = 0;
   long long int offset = 0;
   void *d_data = internal::setup_device_field_decompress(field, stride, offset);
-  
+
   if(d_data == NULL)
   {
     // null means the array is non-contiguous host mem which is not supported
@@ -467,7 +648,7 @@ cuda_decompress(zfp_stream *stream, zfp_field *field)
     std::cerr<<"Cannot decompress: type unknown\n";
   }
 
-   
+
   size_t type_size = zfp_type_size(field->type);
 
   size_t field_size = 1;
@@ -478,11 +659,11 @@ cuda_decompress(zfp_stream *stream, zfp_field *field)
       field_size *= dims[i];
     }
   }
-  
+
   size_t bytes = type_size * field_size;
   internal::cleanup_device_ptr(stream->stream->begin, d_stream, 0, 0, field->type);
   internal::cleanup_device_ptr(field->data, d_data, bytes, offset, field->type);
-  
+
   // this is how zfp determins if this was a success
   size_t words_read = decoded_bytes / sizeof(Word);
   stream->stream->bits = wsize;

--- a/src/cuda_zfp/cuZFP.h
+++ b/src/cuda_zfp/cuZFP.h
@@ -6,7 +6,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-  size_t cuda_compress(zfp_stream *stream, const zfp_field *field);
+  size_t cuda_compress(zfp_stream *stream, const zfp_field *field, int variable_rate);
   void cuda_decompress(zfp_stream *stream, zfp_field *field);
 #ifdef __cplusplus
 }

--- a/src/cuda_zfp/shared.h
+++ b/src/cuda_zfp/shared.h
@@ -18,6 +18,11 @@ typedef unsigned long long Word;
 
 #define NBMASK 0xaaaaaaaaaaaaaaaaull
 
+#define ZFP_1D_BLOCK_SIZE 4 
+#define ZFP_2D_BLOCK_SIZE 16 
+#define ZFP_3D_BLOCK_SIZE 64
+#define ZFP_4D_BLOCK_SIZE 256
+
 namespace cuZFP
 {
 

--- a/src/cuda_zfp/variable.cuh
+++ b/src/cuda_zfp/variable.cuh
@@ -99,13 +99,8 @@ namespace cuZFP
                     mask &= 0xffffffff << misaligned;
                 if ((i + 1) * 32 > misaligned + length_bits)
                     mask &= ~(0xffffffff << ((misaligned + length_bits) & 31));
-
-                // If the mask is full, no need to use atomics
-                // TODO : Try atomics all the time
-                if (mask == 0xffffffff)
-                    sm_out[off_smout + i] = v1;
-                else
-                    atomicAdd(sm_out + off_smout + i, v1 & mask);
+                
+                atomicAdd(sm_out + off_smout + i, v1 & mask);
             }
         }
 

--- a/src/cuda_zfp/variable.cuh
+++ b/src/cuda_zfp/variable.cuh
@@ -1,0 +1,298 @@
+#ifndef CU_ZFP_VARIABLE_CUH
+#define CU_ZFP_VARIABLE_CUH
+
+#include "shared.h"
+
+#include <cub/cub.cuh>
+
+#include <cooperative_groups.h> // Requires CUDA >= 9
+namespace cg = cooperative_groups;
+
+namespace cuZFP
+{
+
+    // *******************************************************************************
+
+    // Copy a chunk of 16-bit stream lengths into the 64-bit offsets array
+    // to compute prefix sums. The first value in offsets is the "base" of the prefix sum
+    __global__ void copy_length(ushort *length,
+                                unsigned long long *offsets,
+                                unsigned long long first_stream,
+                                int nstreams_chunk)
+    {
+        int index = blockIdx.x * blockDim.x + threadIdx.x;
+        if (index >= nstreams_chunk)
+            return;
+        offsets[index + 1] = length[first_stream + index];
+    }
+
+    void copy_length_launch(ushort *bitlengths,
+                            unsigned long long *chunk_offsets,
+                            unsigned long long first,
+                            int nstreams_chunk)
+    {
+        dim3 blocks((nstreams_chunk - 1) / 1024 + 1, 1, 1);
+        copy_length<<<blocks, 1024>>>(bitlengths, chunk_offsets, first, nstreams_chunk);
+    }
+
+    // *******************************************************************************
+
+    // Each tile loads the compressed but uncompacted data to shared memory.
+    // Input alignment can be anything (1-bit) as maxbits is not always a multiple of 8,
+    // so the data is aligned on the fly (first bit of the bitstream on bit 0 in shared memory)
+    template <uint tile_size>
+    __device__ inline void load_to_shared(const uint *streams,                   // Input data
+                                          uint *sm,                              // Shared memory
+                                          const unsigned long long &offset_bits, // Offset in bits for the stream
+                                          const uint &length_bits,               // Length in bits for this stream
+                                          const int &maxpad32)                   // Next multiple of 32 of maxbits
+    {
+        uint misaligned = offset_bits & 31;
+        unsigned long long offset_32 = offset_bits / 32;
+        for (int i = threadIdx.x; i * 32 < length_bits; i += tile_size)
+        {
+            // Align even if already aligned
+            uint low = streams[offset_32 + i];
+            uint high = 0;
+            if ((i + 1) * 32 < misaligned + length_bits)
+                high = streams[offset_32 + i + 1];
+            sm[threadIdx.y * maxpad32 + i] = __funnelshift_r(low, high, misaligned);
+        }
+    }
+
+    // Read the input bitstreams from shared memory, align them relative to the
+    // final output alignment, compact all the aligned bitstreams in sm_out,
+    // then write all the data (coalesced) to global memory, using atomics only
+    // for the first and last elements
+    template <int tile_size, int num_tiles>
+    __device__ inline void process(bool valid_stream,
+                                   unsigned long long &offset0,     // Offset in bits of the first bitstream of the block
+                                   const unsigned long long offset, // Offset in bits for this stream
+                                   const int &length_bits,          // length of this stream
+                                   const int &tid,                  // global thread index inside the thread block
+                                   uint *sm_in,                     // shared memory containing the compressed input data
+                                   uint *sm_out,                    // shared memory to stage the compacted compressed data
+                                   uint maxpad32,                   // Leading dimension of the shared memory (padded maxbits)
+                                   uint *sm_length,                 // shared memory to compute a prefix-sum inside the block
+                                   uint *output)                    // output pointer
+    {
+        // All streams in the block will align themselves on the first stream of the block
+        int misaligned0 = offset0 & 31;
+        int misaligned = offset & 31;
+        int off_smin = threadIdx.y * maxpad32;
+        int off_smout = ((int)(offset - offset0) + misaligned0) / 32;
+        offset0 /= 32;
+
+        if (valid_stream)
+        {
+            // Loop on the whole bitstream (including misalignment), 32 bits per thread
+            for (int i = threadIdx.x; i * 32 < misaligned + length_bits; i += tile_size)
+            {
+                // Merge 2 values to create an aligned value
+                uint v0 = i > 0 ? sm_in[off_smin + i - 1] : 0;
+                uint v1 = sm_in[off_smin + i];
+                v1 = __funnelshift_l(v0, v1, misaligned);
+
+                // Mask out neighbor bitstreams
+                uint mask = 0xffffffff;
+                if (i == 0)
+                    mask &= 0xffffffff << misaligned;
+                if ((i + 1) * 32 > misaligned + length_bits)
+                    mask &= ~(0xffffffff << ((misaligned + length_bits) & 31));
+
+                // If the mask is full, no need to use atomics
+                // TODO : Try atomics all the time
+                if (mask == 0xffffffff)
+                    sm_out[off_smout + i] = v1;
+                else
+                    atomicAdd(sm_out + off_smout + i, v1 & mask);
+            }
+        }
+
+        // First thread working on each bistream writes the length in shared memory
+        if (threadIdx.x == 0)
+            sm_length[threadIdx.y] = length_bits;
+
+        // This synchthreads protects sm_out and sm_length.
+        __syncthreads();
+
+        // Compute total length for the threadblock
+        uint total_length = 0;
+        for (int i = tid & 31; i < num_tiles; i += 32)
+            total_length += sm_length[i];
+        for (int i = 1; i < 32; i *= 2)
+            total_length += __shfl_xor_sync(0xffffffff, total_length, i);
+
+        // Write the shared memory output data to global memory, using all the threads
+        for (int i = tid; i * 32 < misaligned0 + total_length; i += tile_size * num_tiles)
+        {
+            // Mask out the beginning and end of the block if unaligned
+            uint mask = 0xffffffff;
+            if (i == 0)
+                mask &= 0xffffffff << misaligned0;
+            if ((i + 1) * 32 > misaligned0 + total_length)
+                mask &= ~(0xffffffff << ((misaligned0 + total_length) & 31));
+            // Reset the shared memory to zero for the next iteration.
+            uint value = sm_out[i];
+            sm_out[i] = 0;
+            // Write to global memory. Use atomicCAS for partially masked values
+            // Working in-place, the output buffer has not been memset to zero
+            if (mask == 0xffffffff)
+                output[offset0 + i] = value;
+            else
+            {
+                uint assumed, old = output[offset0 + i];
+                do
+                {
+                    assumed = old;
+                    old = atomicCAS(output + offset0 + i, assumed, (assumed & ~mask) + (value & mask));
+                } while (assumed != old);
+            }
+        }
+    }
+
+    // In-place bitstream concatenation: compacting blocks containing different number
+    // of bits, with the input blocks stored in bins of the same size
+    // Using a 2D tile of threads,
+    // threadIdx.y = Index of the stream
+    // threadIdx.x = Threads working on the same stream
+    // Must launch dim3(tile_size, num_tiles, 1) threads per block.
+    // Offsets has a length of (nstreams_chunk + 1), offsets[0] is the offset in bits
+    // where stream 0 starts, it must be memset to zero before launching the very first chunk,
+    // and is updated at the end of this kernel.
+    template <int tile_size, int num_tiles>
+    __launch_bounds__(tile_size *num_tiles)
+        __global__ void concat_bitstreams_chunk(uint *__restrict__ streams,
+                                                unsigned long long *__restrict__ offsets,
+                                                unsigned long long first_stream_chunk,
+                                                int nstreams_chunk,
+                                                int maxbits,
+                                                int maxpad32)
+    {
+        cg::grid_group grid = cg::this_grid();
+        __shared__ uint sm_length[num_tiles];
+        extern __shared__ uint sm_in[];              // sm_in[num_tiles * maxpad32]
+        uint *sm_out = sm_in + num_tiles * maxpad32; // sm_out[num_tiles * maxpad32 + 1]
+        int tid = threadIdx.y * tile_size + threadIdx.x;
+        int grid_stride = gridDim.x * num_tiles;
+        int first_bitstream_block = blockIdx.x * num_tiles;
+        int my_stream = first_bitstream_block + threadIdx.y;
+
+        // Zero the output shared memory. Will be reset again inside process().
+        for (int i = tid; i < num_tiles * maxpad32 + 1; i += tile_size * num_tiles)
+            sm_out[i] = 0;
+
+        // Loop on all the bitstreams of the current chunk, using the whole resident grid.
+        // All threads must enter this loop, as they have to synchronize inside.
+        for (int i = 0; i < nstreams_chunk; i += grid_stride)
+        {
+            bool valid_stream = my_stream + i < nstreams_chunk;
+            unsigned long long offset0 = offsets[first_bitstream_block + i];
+            unsigned long long offset = 0;
+            uint length_bits = 0;
+            if (valid_stream)
+            {
+                offset = offsets[my_stream + i];
+                unsigned long long offset_bits = (first_stream_chunk + my_stream + i) * maxbits;
+                length_bits = (uint)(offsets[my_stream + i + 1] - offset);
+                load_to_shared<tile_size>(streams, sm_in, offset_bits, length_bits, maxpad32);
+            }
+
+            // Check if there is overlap between input and output at the grid level.
+            // Grid sync if needed, otherwise just syncthreads to protect the shared memory.
+            int last_stream = min(nstreams_chunk, i + grid_stride);
+            unsigned long long writing_to = (offsets[last_stream] + 31) / 32;
+            unsigned long long reading_from = (first_stream_chunk + i) * maxbits;
+            if (writing_to >= reading_from)
+                grid.sync();
+            else
+                __syncthreads();
+
+            // Compact the shared memory data and write it to global memory
+            process<tile_size, num_tiles>(valid_stream, offset0, offset, length_bits, tid,
+                                          sm_in, sm_out, maxpad32, sm_length, streams);
+        }
+
+        // Reset the base of the offsets array, for the next chunk's prefix sum
+        if (blockIdx.x == 0 && tid == 0)
+            offsets[0] = offsets[nstreams_chunk];
+    }
+
+    void chunk_process_launch(uint *streams,
+                              unsigned long long *chunk_offsets,
+                              unsigned long long first,
+                              int nstream_chunk,
+                              int nbitsmax,
+                              int num_sm)
+    {
+        int maxpad32 = (nbitsmax + 31) / 32;
+        void *kernelArgs[] = {(void *)&streams,
+                              (void *)&chunk_offsets,
+                              (void *)&first,
+                              (void *)&nstream_chunk,
+                              (void *)&nbitsmax,
+                              (void *)&maxpad32};
+        // Increase the number of threads per ZFP block ("tile") as nbitsmax increases
+        // Compromise between coalescing, inactive threads and shared memory size <= 48KB
+        // Total shared memory used = (2 * num_tiles * maxpad + 1) x 32-bit dynamic shared memory
+        // and num_tiles x 32-bit static shared memory.
+        // Boundaries set so that the shared memory stays < 48KB.
+        int max_blocks = 0;
+        if (nbitsmax <= 352)
+        {
+            constexpr int tile_size = 1;
+            constexpr int num_tiles = 512;
+            size_t shmem = (2 * num_tiles * maxpad32 + 1) * sizeof(uint);
+            cudaOccupancyMaxActiveBlocksPerMultiprocessor(&max_blocks,
+                                                          concat_bitstreams_chunk<tile_size, num_tiles>,
+                                                          tile_size * num_tiles, shmem);
+            max_blocks *= num_sm;
+            dim3 threads(tile_size, num_tiles, 1);
+            cudaLaunchCooperativeKernel((void *)concat_bitstreams_chunk<tile_size, num_tiles>,
+                                        dim3(max_blocks, 1, 1), threads, kernelArgs, shmem, 0);
+        }
+        else if (nbitsmax <= 1504)
+        {
+            constexpr int tile_size = 4;
+            constexpr int num_tiles = 128;
+            size_t shmem = (2 * num_tiles * maxpad32 + 1) * sizeof(uint);
+            cudaOccupancyMaxActiveBlocksPerMultiprocessor(&max_blocks,
+                                                          concat_bitstreams_chunk<tile_size, num_tiles>,
+                                                          tile_size * num_tiles, shmem);
+            max_blocks *= num_sm;
+            dim3 threads(tile_size, num_tiles, 1);
+            cudaLaunchCooperativeKernel((void *)concat_bitstreams_chunk<tile_size, num_tiles>,
+                                        dim3(max_blocks, 1, 1), threads, kernelArgs, shmem, 0);
+        }
+        else if (nbitsmax <= 6112)
+        {
+            constexpr int tile_size = 16;
+            constexpr int num_tiles = 32;
+            size_t shmem = (2 * num_tiles * maxpad32 + 1) * sizeof(uint);
+            cudaOccupancyMaxActiveBlocksPerMultiprocessor(&max_blocks,
+                                                          concat_bitstreams_chunk<tile_size, num_tiles>,
+                                                          tile_size * num_tiles, shmem);
+            max_blocks *= num_sm;
+            dim3 threads(tile_size, num_tiles, 1);
+            cudaLaunchCooperativeKernel((void *)concat_bitstreams_chunk<tile_size, num_tiles>,
+                                        dim3(max_blocks, 1, 1), threads, kernelArgs, shmem, 0);
+        }
+        else // Up to 24512 bits, so works even for largest 4D.
+        {
+            constexpr int tile_size = 64;
+            constexpr int num_tiles = 8;
+            size_t shmem = (2 * num_tiles * maxpad32 + 1) * sizeof(uint);
+            cudaOccupancyMaxActiveBlocksPerMultiprocessor(&max_blocks,
+                                                          concat_bitstreams_chunk<tile_size, num_tiles>,
+                                                          tile_size * num_tiles, shmem);
+            max_blocks *= num_sm;
+            dim3 threads(tile_size, num_tiles, 1);
+            cudaLaunchCooperativeKernel((void *)concat_bitstreams_chunk<tile_size, num_tiles>,
+                                        dim3(max_blocks, 1, 1), threads, kernelArgs, shmem, 0);
+        }
+    }
+
+    // *******************************************************************************
+
+} // namespace cuZFP
+#endif

--- a/src/inline/bitstream.c
+++ b/src/inline/bitstream.c
@@ -129,6 +129,7 @@ struct bitstream {
   word* ptr;   /* pointer to next word to be read/written */
   word* begin; /* beginning of stream */
   word* end;   /* end of stream (currently unused) */
+  ushort *bitlengths; /* Individual block lengths (for variable bit rate) */
 #ifdef BIT_STREAM_STRIDED
   size_t mask;     /* one less the block size in number of words */
   ptrdiff_t delta; /* number of words between consecutive blocks */
@@ -436,6 +437,7 @@ stream_open(void* buffer, size_t bytes)
   if (s) {
     s->begin = (word*)buffer;
     s->end = s->begin + bytes / sizeof(word);
+    s->bitlengths = NULL;
 #ifdef BIT_STREAM_STRIDED
     stream_set_stride(s, 0, 0);
 #endif

--- a/src/template/cudacompress.c
+++ b/src/template/cudacompress.c
@@ -5,40 +5,32 @@
 static void 
 _t2(compress_cuda, Scalar, 1)(zfp_stream* stream, const zfp_field* field)
 {
-  if(zfp_stream_compression_mode(stream) == zfp_mode_fixed_rate)
-  { 
-    cuda_compress(stream, field);   
-  }
+  int variable_rate = zfp_stream_compression_mode(stream) != zfp_mode_fixed_rate;
+  cuda_compress(stream, field, variable_rate);   
 }
 
 /* compress 1d strided array */
 static void 
 _t2(compress_strided_cuda, Scalar, 1)(zfp_stream* stream, const zfp_field* field)
 {
-  if(zfp_stream_compression_mode(stream) == zfp_mode_fixed_rate)
-  {
-    cuda_compress(stream, field);   
-  }
+  int variable_rate = zfp_stream_compression_mode(stream) != zfp_mode_fixed_rate;
+  cuda_compress(stream, field, variable_rate);   
 }
 
 /* compress 2d strided array */
 static void 
 _t2(compress_strided_cuda, Scalar, 2)(zfp_stream* stream, const zfp_field* field)
 {
-  if(zfp_stream_compression_mode(stream) == zfp_mode_fixed_rate)
-  {
-    cuda_compress(stream, field);   
-  }
+  int variable_rate = zfp_stream_compression_mode(stream) != zfp_mode_fixed_rate;
+  cuda_compress(stream, field, variable_rate);   
 }
 
 /* compress 3d strided array */
 static void
 _t2(compress_strided_cuda, Scalar, 3)(zfp_stream* stream, const zfp_field* field)
 {
-  if(zfp_stream_compression_mode(stream) == zfp_mode_fixed_rate)
-  {
-    cuda_compress(stream, field);   
-  }
+  int variable_rate = zfp_stream_compression_mode(stream) != zfp_mode_fixed_rate;
+  cuda_compress(stream, field, variable_rate);   
 }
 
 #endif

--- a/src/zfp.c
+++ b/src/zfp.c
@@ -252,6 +252,17 @@ zfp_field_size_bytes(const zfp_field* field)
   return field_index_span(field, NULL, NULL) * type_precision(field->type);
 }
 
+size_t
+zfp_field_num_blocks (const zfp_field* field)
+{
+  uint mx = (MAX(field->nx, 1u) + 3) / 4;
+  uint my = (MAX(field->ny, 1u) + 3) / 4;
+  uint mz = (MAX(field->nz, 1u) + 3) / 4;
+  uint mw = (MAX(field->nw, 1u) + 3) / 4;
+  size_t blocks = (size_t)mx * (size_t)my * (size_t)mz * (size_t)mw;
+  return blocks;
+}
+
 zfp_bool
 zfp_field_stride(const zfp_field* field, int* stride)
 {
@@ -657,8 +668,7 @@ uint zfp_block_maxbits(const zfp_stream* zfp, const zfp_field* field)
       return 0;
   }
   maxbits += values - 1 + values * MIN(zfp->maxprec, type_precision(field->type));
-  // Make it a multiple of 8 bits, (needed for CUDA)
-  maxbits = (maxbits + 7) & ~7u;
+
   return maxbits;
 }
 
@@ -668,11 +678,7 @@ zfp_stream_maximum_size(const zfp_stream* zfp, const zfp_field* field)
   uint maxbits = zfp_block_maxbits (zfp, field);
   if (!maxbits)
     return 0;
-  uint mx = (MAX(field->nx, 1u) + 3) / 4;
-  uint my = (MAX(field->ny, 1u) + 3) / 4;
-  uint mz = (MAX(field->nz, 1u) + 3) / 4;
-  uint mw = (MAX(field->nw, 1u) + 3) / 4;
-  size_t blocks = (size_t)mx * (size_t)my * (size_t)mz * (size_t)mw;
+  size_t blocks = zfp_field_num_blocks (field);
 
   maxbits = MIN(maxbits, zfp->maxbits);
   maxbits = MAX(maxbits, zfp->minbits);

--- a/src/zfp.c
+++ b/src/zfp.c
@@ -632,19 +632,12 @@ zfp_stream_compressed_size(const zfp_stream* zfp)
   return stream_size(zfp->stream);
 }
 
-size_t
-zfp_stream_maximum_size(const zfp_stream* zfp, const zfp_field* field)
+uint zfp_block_maxbits(const zfp_stream* zfp, const zfp_field* field)
 {
   int reversible = is_reversible(zfp);
   uint dims = zfp_field_dimensionality(field);
-  uint mx = (MAX(field->nx, 1u) + 3) / 4;
-  uint my = (MAX(field->ny, 1u) + 3) / 4;
-  uint mz = (MAX(field->nz, 1u) + 3) / 4;
-  uint mw = (MAX(field->nw, 1u) + 3) / 4;
-  size_t blocks = (size_t)mx * (size_t)my * (size_t)mz * (size_t)mw;
   uint values = 1u << (2 * dims);
   uint maxbits = 0;
-
   if (!dims)
     return 0;
   switch (field->type) {
@@ -664,6 +657,23 @@ zfp_stream_maximum_size(const zfp_stream* zfp, const zfp_field* field)
       return 0;
   }
   maxbits += values - 1 + values * MIN(zfp->maxprec, type_precision(field->type));
+  // Make it a multiple of 8 bits, (needed for CUDA)
+  maxbits = (maxbits + 7) & ~7u;
+  return maxbits;
+}
+
+size_t
+zfp_stream_maximum_size(const zfp_stream* zfp, const zfp_field* field)
+{
+  uint maxbits = zfp_block_maxbits (zfp, field);
+  if (!maxbits)
+    return 0;
+  uint mx = (MAX(field->nx, 1u) + 3) / 4;
+  uint my = (MAX(field->ny, 1u) + 3) / 4;
+  uint mz = (MAX(field->nz, 1u) + 3) / 4;
+  uint mw = (MAX(field->nw, 1u) + 3) / 4;
+  size_t blocks = (size_t)mx * (size_t)my * (size_t)mz * (size_t)mw;
+
   maxbits = MIN(maxbits, zfp->maxbits);
   maxbits = MAX(maxbits, zfp->minbits);
   return ((ZFP_HEADER_MAX_BITS + blocks * maxbits + stream_word_bits - 1) & ~(stream_word_bits - 1)) / CHAR_BIT;


### PR DESCRIPTION
Work in progress.
Compression with variable bit rate seems to work on GPU, but needs more testing.
The individual lengths of each block are not saved unless the user provides a pointer through the bitstream struct (need a way to set it).

The variable bit rate requires CUDA 9 (cooperative launch and grid sync, to compact the data in-place). Need to hide the variable bit rate code for CUDA <9, or bump up the min requirement to 9?
The code uses CUB which is included in CUDA 11+, but available otherwise (todo: update cmake to download it).
If CUDA 11.2 is found, the temporary memories on GPU are allocated with cudaMallocAsync.
