### PR TITLE
Only call cudaGetDeviceProperties once.

### DIFF
--- a/src/cuda_zfp/shared.h
+++ b/src/cuda_zfp/shared.h
@@ -84,9 +84,17 @@ size_t calc_device_mem3d(const uint3 encoded_dims,
 
 dim3 get_max_grid_dims()
 {
-  cudaDeviceProp prop; 
-  int device = 0;
-  cudaGetDeviceProperties(&prop, device);
+  static cudaDeviceProp prop;
+  static bool firstTime = true;
+
+  if( firstTime )
+  {
+    firstTime = false;
+
+    int device = 0;
+    cudaGetDeviceProperties(&prop, device);
+  }
+
   dim3 grid_dims;
   grid_dims.x = prop.maxGridSize[0];
   grid_dims.y = prop.maxGridSize[1];


### PR DESCRIPTION
While debugging I added some timers to `encode3launch` and got the following results for a single precision field of size 528x520x512 on device.

Previously
```
Time between entering encode3launch and cudaMemset: 0.617ms
Encode elapsed time: 0.00064 (s)
# encode3 rate: 817.93 (GB / sec)

100 calls to `zfp_compress`: 0.158 s
100 calls to `zfp_decompress`: 0.228 s
```

Now
```
Time between entering encode3launch and cudaMemset: 0.000ms
Encode elapsed time: 0.00064 (s)
# encode3 rate: 818.09 (GB / sec)

100 calls to `zfp_compress`: 0.077 s
100 calls to `zfp_decompress`: 0.166 s
```

I guess this would break things if in between calls to ZFP the user set the active device and the new active device had a different max grid size, but I doubt anyone is doing that.