### PR TITLE
CMake: (fix) OpenMP dependency.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,4 @@
-if(WIN32)
-  cmake_minimum_required(VERSION 3.4)
-else()
-  cmake_minimum_required(VERSION 3.1)
-endif()
+cmake_minimum_required(VERSION 3.9)
 
 # Fail immediately if not using an out-of-source build
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,11 +1,11 @@
 if(ZFP_WITH_CUDA)
-  SET(CMAKE_CXX_FLAGS_PREVIOUS ${CMAKE_CXX_FLAGS})
-  SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fPIC" )
+  set(CMAKE_CXX_FLAGS_PREVIOUS ${CMAKE_CXX_FLAGS})
+  set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fPIC" )
 
   add_subdirectory(cuda_zfp)
   cuda_include_directories(${PROJECT_SOURCE_DIR}/include)
   cuda_wrap_srcs(zfp OBJ zfp_cuda_backend_obj cuda_zfp/cuZFP.cu OPTIONS ${CMAKE_CUDA_FLAGS})
-  SET(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS_PREVIOUS})
+  set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS_PREVIOUS})
   add_definitions(-DZFP_WITH_CUDA)
 endif()
 
@@ -28,8 +28,7 @@ add_library(zfp ${zfp_source}
 add_library(zfp::zfp ALIAS zfp)
 
 if(ZFP_WITH_OPENMP)
-  target_compile_options(zfp PRIVATE ${OpenMP_C_FLAGS})
-  target_link_libraries(zfp PRIVATE ${OpenMP_C_LIBRARIES})
+  target_link_libraries(zfp PRIVATE OpenMP::OpenMP_C)
 endif()
 
 if(HAVE_LIBM_MATH)

--- a/zfp-config.cmake.in
+++ b/zfp-config.cmake.in
@@ -3,6 +3,7 @@
 # It defines the following variables
 #  ZFP_INCLUDE_DIRS - include directories for zfp
 #  ZFP_LIBRARIES    - libraries to link against
+#  ZFP_WITH_OPENMP  - Indicates if the zfp library has been built with OpenMP support.
 #
 # And the following imported targets:
 #   zfp::zfp
@@ -22,3 +23,7 @@ set(ZFP_LIBRARIES zfp::zfp)
 set(ZFP_INCLUDE_DIRS
   $<TARGET_PROPERTY:zfp::zfp,INTERFACE_INCLUDE_DIRECTORIES>
 )
+set(ZFP_WITH_OPENMP @ZFP_WITH_OPENMP@)
+if(ZFP_WITH_OPENMP)
+  find_package(OpenMP REQUIRED COMPONENTS C)
+endif()


### PR DESCRIPTION
Hello,

In the original implementation the OpenMP libraries has been added
to the INTERFACE_LINK_LIBRARIES in the zfp-targets.cmake file using
an absolute path. This works but it is not portable. Using CMake
version 3.9 and latter the find_package(OpenMP ...) has been
significantly improved which allows for a relocatable solution of the
CMake config files. In addition, added ZFP_WITH_OPENMP variable to the
config file zfp-config.cmake to indicate if the zfp library has
been built with OpenMP support. If true, load the OpenMP package
using find_package(OpenMP ...).

Maybe a similar thing can be done for CUDA. Unfortunately, I do not 
have access to both CUDA and nVidia GPU therefore I cannot investigate
how this should be done in your CMake configuration.

Best regards,
   Jan-Willem