### PR TITLE
Feature/cuda variable rate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,13 +175,13 @@ if(ZFP_WITH_CUDA)
   if(NOT CUDA_FOUND)
     message(FATAL_ERROR "ZFP_WITH_CUDA is enabled, but a CUDA installation was not found.")
   endif()
-  if(${CUDA_VERSION_MAJOR} LESS 7)
-    message(FATAL_ERROR "zfp requires at least CUDA 7.0.")
+  if(${CUDA_VERSION_MAJOR} LESS 9)
+    message(FATAL_ERROR "zfp requires at least CUDA 9.0.")
   endif()
   if(${CUDA_VERSION_MAJOR} LESS 11)
     # CUB is part of CUDA since CUDA 11
     # Todo: get CUB from https://github.com/NVIDIA/cub.git
-    message(FATAL_ERROR "zfp requires at least CUDA 7.0.")
+    message(FATAL_ERROR "TODO: Install CUB for CUDA < 11")
   endif()
   set (CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} \
                         -gencode arch=compute_35,code=compute_35 \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,7 +183,10 @@ if(ZFP_WITH_CUDA)
     # Todo: get CUB from https://github.com/NVIDIA/cub.git
     message(FATAL_ERROR "zfp requires at least CUDA 7.0.")
   endif()
-  # set (CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -G -g")
+  set (CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} \
+                        -gencode arch=compute_35,code=compute_35 \
+                        -gencode arch=compute_60,code=compute_60 \
+                        -gencode arch=compute_70,code=compute_70")
 endif()
 
 if(NOT (ZFP_BIT_STREAM_WORD_SIZE EQUAL 64))

--- a/src/cuda_zfp/cuZFP.cu
+++ b/src/cuda_zfp/cuZFP.cu
@@ -470,6 +470,18 @@ void cleanup_device_ptr(void *orig_ptr, void *d_ptr, size_t bytes, long long int
 size_t
 cuda_compress(zfp_stream *stream, const zfp_field *field, int variable_rate)
 {
+
+#if (CUDART_VERSION < 9000)
+  if (variable_rate)
+    return 0; // Variable rate requires CUDA >= 9
+#endif
+
+  if (zfp_stream_compression_mode(stream) == zfp_mode_reversible)
+  {
+    // Reversible mode not supported on GPU
+    return 0;
+  }
+
   uint dims[3];
   dims[0] = field->nx;
   dims[1] = field->ny;
@@ -487,17 +499,6 @@ cuda_compress(zfp_stream *stream, const zfp_field *field, int variable_rate)
   if(d_data == NULL)
   {
     // null means the array is non-contiguous host mem which is not supported
-    return 0;
-  }
-
-#if (CUDART_VERSION < 9000)
-  if (variable_rate)
-    return 0; // Variable rate requires CUDA >= 9
-#endif
-
-  if (zfp_stream_compression_mode(stream) == zfp_mode_reversible)
-  {
-    // Reversible mode not supported on GPU
     return 0;
   }
 

--- a/src/cuda_zfp/cuZFP.cu
+++ b/src/cuda_zfp/cuZFP.cu
@@ -495,6 +495,12 @@ cuda_compress(zfp_stream *stream, const zfp_field *field, int variable_rate)
     return 0; // Variable rate requires CUDA >= 9
 #endif
 
+  if (zfp_stream_compression_mode(stream) == zfp_mode_reversible)
+  {
+    // Reversible mode not supported on GPU
+    return 0;
+  }
+
   int num_sm;
   cudaDeviceGetAttribute(&num_sm, cudaDevAttrMultiProcessorCount, 0);
 

--- a/src/cuda_zfp/cuZFP.cu
+++ b/src/cuda_zfp/cuZFP.cu
@@ -580,8 +580,9 @@ cuda_compress(zfp_stream *stream, const zfp_field *field, int variable_rate)
       cuZFP::chunk_process_launch((uint*)d_stream, d_offsets, i, cur_blocks, last_chunk, buffer_maxbits, num_sm);
     }
     // The total length in bits is now in the base of the prefix sum.
+    // but it excludes the 64-bit "add_padding". -> Pad to 64b, convert to bytes
     cudaMemcpy (&stream_bytes, d_offsets, sizeof (unsigned long long), cudaMemcpyDeviceToHost);
-    stream_bytes = (stream_bytes + 7) / 8;
+    stream_bytes = ((stream_bytes + 63) / 64) * 8;
   }
 
   internal::cleanup_device_ptr(stream->stream->begin, d_stream, stream_bytes, 0, field->type);


### PR DESCRIPTION
- Fixed bug that could create invalid checksums (from zero-padded area at the very end). The size wasn't rounded properly to the next multiple of 64b.
- Added missing validity check for first stream of the block, this could create out of bounds memory accesses.