### PR TITLE
Adding GitHub citation file to make zfp easier to cite!

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,10 @@
+cff-version: 1.1.0
+message: "If you use this software, please cite it as below."
+authors:
+  - family-names: Lindstrom
+    given-names: Peter
+    orcid: https://orcid.org/0000-0003-3817-4199
+title: "Fixed-Rate Compressed Floating-Point Arrays"
+version: develop
+doi: 10.1109/TVCG.2014.2346458
+date-released: 2014-11-05


### PR DESCRIPTION
Hi zfp team!

GitHub has [recently added](https://twitter.com/natfriedman/status/1420122675813441540) this standard file, CITATION.cff, that will render a sidebar link to easily copy paste bibtex information to cite the work. it looks super cool, and I thought this would be great for LLNL projects, and I found that you have a publication so I'm adding the file here.  Since an exact version is required for the entry (it will not render without it) and it seems more logical to put a general string that the copy-paster can modify for their needs, the workaround that I've seen people using is to indicate the develop or main branch, as I've done here.

I hope this might be useful!

Signed-off-by: vsoch <vsoch@users.noreply.github.com>