### PR TITLE
Fix exception handling in compress_numpy

### DIFF
--- a/python/zfpy.pyx
+++ b/python/zfpy.pyx
@@ -74,7 +74,7 @@ cpdef ztype_to_dtype(zfp_type ztype):
     except KeyError:
         raise ValueError("Unsupported zfp_type {}".format(ztype))
 
-cdef zfp_field* _init_field(np.ndarray arr):
+cdef zfp_field* _init_field(np.ndarray arr) except NULL:
     shape = arr.shape
     cdef int ndim = arr.ndim
     cdef zfp_type ztype = dtype_to_ztype(arr.dtype)


### PR DESCRIPTION
Without this a segfault would happen if there is an exception in `_init_field`