### PR TITLE
Fix typos found by codespell

### DIFF
--- a/array/zfp/handle1.h
+++ b/array/zfp/handle1.h
@@ -24,7 +24,7 @@ protected:
   // protected constructor
   explicit const_handle(const container_type* container, size_t x) : container(const_cast<container_type*>(container)), x(x) {}
 
-  // derefence handle
+  // dereference handle
   value_type get() const { return container->get(x); }
 
   container_type* container; // container

--- a/array/zfp/handle2.h
+++ b/array/zfp/handle2.h
@@ -24,7 +24,7 @@ protected:
   // protected constructor
   explicit const_handle(const container_type* container, size_t x, size_t y) : container(const_cast<container_type*>(container)), x(x), y(y) {}
 
-  // derefence handle
+  // dereference handle
   value_type get() const { return container->get(x, y); }
 
   container_type* container; // container

--- a/array/zfp/handle3.h
+++ b/array/zfp/handle3.h
@@ -24,7 +24,7 @@ protected:
   // protected constructor
   explicit const_handle(const container_type* container, size_t x, size_t y, size_t z) : container(const_cast<container_type*>(container)), x(x), y(y), z(z) {}
 
-  // derefence handle
+  // dereference handle
   value_type get() const { return container->get(x, y, z); }
 
   container_type* container; // container

--- a/array/zfp/handle4.h
+++ b/array/zfp/handle4.h
@@ -24,7 +24,7 @@ protected:
   // protected constructor
   explicit const_handle(const container_type* container, size_t x, size_t y, size_t z, size_t w) : container(const_cast<container_type*>(container)), x(x), y(y), z(z), w(w) {}
 
-  // derefence handle
+  // dereference handle
   value_type get() const { return container->get(x, y, z, w); }
 
   container_type* container; // container

--- a/docs/source/arrays.rst
+++ b/docs/source/arrays.rst
@@ -716,7 +716,7 @@ Additional methods are documented below.
   Whereas the :ref:`read-write fixed-rate arrays <array_classes>`
   (:cpp:class:`zfp::array`) require that block storage is word aligned, the
   read-only arrays (:cpp:class:`zfp::const_array`) are not subject to such
-  restrictions and thefore support finer rate granularity.  For a
+  restrictions and therefore support finer rate granularity.  For a
   *d*-dimensional :cpp:class:`const_array`, the rate granularity is
   4\ :sup:`-d` bits/value, e.g., a quarter bit/value for 1D arrays.
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(zfpy MODULE ${zfpy})
 target_link_libraries(zfpy zfp)
 python_extension_module(zfpy)
 
-# Build to the currrent binary dir to avoid conflicts with other libraries named zfp
+# Build to the current binary dir to avoid conflicts with other libraries named zfp
 set(PYLIB_BUILD_DIR "${CMAKE_BINARY_DIR}/bin" CACHE PATH "Directory where zfp python library will be built")
 set_target_properties(zfpy PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PYLIB_BUILD_DIR})
 

--- a/src/cuda_zfp/cuZFP.cu
+++ b/src/cuda_zfp/cuZFP.cu
@@ -483,7 +483,7 @@ cuda_decompress(zfp_stream *stream, zfp_field *field)
   internal::cleanup_device_ptr(stream->stream->begin, d_stream, 0, 0, field->type);
   internal::cleanup_device_ptr(field->data, d_data, bytes, offset, field->type);
   
-  // this is how zfp determins if this was a success
+  // this is how zfp determines if this was a success
   size_t words_read = decoded_bytes / sizeof(Word);
   stream->stream->bits = wsize;
   // set stream pointer to end of stream

--- a/src/cuda_zfp/decode.cuh
+++ b/src/cuda_zfp/decode.cuh
@@ -112,7 +112,7 @@ public:
       next_read = n_bits - first_read; 
     }
    
-    // this is basically a no-op when first read constained 
+    // this is basically a no-op when first read contained 
     // all the bits. TODO: if we have aligned reads, this could 
     // be a conditional without divergence
     mask = ((Word)1<<((next_read)))-1;

--- a/src/cuda_zfp/decode1.cuh
+++ b/src/cuda_zfp/decode1.cuh
@@ -127,9 +127,9 @@ size_t decode1launch(uint dim,
   cudaEventSynchronize(stop);
 	cudaStreamSynchronize(0);
 
-  float miliseconds = 0;
-  cudaEventElapsedTime(&miliseconds, start, stop);
-  float seconds = miliseconds / 1000.f;
+  float milliseconds = 0;
+  cudaEventElapsedTime(&milliseconds, start, stop);
+  float seconds = milliseconds / 1000.f;
   float rate = (float(dim) * sizeof(Scalar) ) / seconds;
   rate /= 1024.f;
   rate /= 1024.f;

--- a/src/cuda_zfp/decode2.cuh
+++ b/src/cuda_zfp/decode2.cuh
@@ -150,9 +150,9 @@ size_t decode2launch(uint2 dims,
   cudaEventSynchronize(stop);
 	cudaStreamSynchronize(0);
 
-  float miliseconds = 0;
-  cudaEventElapsedTime(&miliseconds, start, stop);
-  float seconds = miliseconds / 1000.f;
+  float milliseconds = 0;
+  cudaEventElapsedTime(&milliseconds, start, stop);
+  float seconds = milliseconds / 1000.f;
   float rate = (float(dims.x * dims.y) * sizeof(Scalar) ) / seconds;
   rate /= 1024.f;
   rate /= 1024.f;

--- a/src/cuda_zfp/decode3.cuh
+++ b/src/cuda_zfp/decode3.cuh
@@ -163,9 +163,9 @@ size_t decode3launch(uint3 dims,
   cudaEventSynchronize(stop);
 	cudaStreamSynchronize(0);
 
-  float miliseconds = 0;
-  cudaEventElapsedTime(&miliseconds, start, stop);
-  float seconds = miliseconds / 1000.f;
+  float milliseconds = 0;
+  cudaEventElapsedTime(&milliseconds, start, stop);
+  float seconds = milliseconds / 1000.f;
   float rate = (float(dims.x * dims.y * dims.z) * sizeof(Scalar) ) / seconds;
   rate /= 1024.f;
   rate /= 1024.f;

--- a/src/cuda_zfp/encode1.cuh
+++ b/src/cuda_zfp/encode1.cuh
@@ -145,9 +145,9 @@ size_t encode1launch(uint dim,
   cudaEventSynchronize(stop);
   cudaStreamSynchronize(0);
 
-  float miliseconds = 0.f;
-  cudaEventElapsedTime(&miliseconds, start, stop);
-  float seconds = miliseconds / 1000.f;
+  float milliseconds = 0.f;
+  cudaEventElapsedTime(&milliseconds, start, stop);
+  float seconds = milliseconds / 1000.f;
   float gb = (float(dim) * float(sizeof(Scalar))) / (1024.f * 1024.f * 1024.f);
   float rate = gb / seconds;
   printf("Encode elapsed time: %.5f (s)\n", seconds);

--- a/src/cuda_zfp/encode2.cuh
+++ b/src/cuda_zfp/encode2.cuh
@@ -163,9 +163,9 @@ size_t encode2launch(uint2 dims,
   cudaEventSynchronize(stop);
   cudaStreamSynchronize(0);
 
-  float miliseconds = 0.f;
-  cudaEventElapsedTime(&miliseconds, start, stop);
-  float seconds = miliseconds / 1000.f;
+  float milliseconds = 0.f;
+  cudaEventElapsedTime(&milliseconds, start, stop);
+  float seconds = milliseconds / 1000.f;
   float mb = (float(dims.x * dims.y) * sizeof(Scalar)) / (1024.f * 1024.f *1024.f);
   float rate = mb / seconds;
   printf("Encode elapsed time: %.5f (s)\n", seconds);

--- a/src/cuda_zfp/encode3.cuh
+++ b/src/cuda_zfp/encode3.cuh
@@ -171,9 +171,9 @@ size_t encode3launch(uint3 dims,
   cudaEventSynchronize(stop);
   cudaStreamSynchronize(0);
 
-  float miliseconds = 0;
-  cudaEventElapsedTime(&miliseconds, start, stop);
-  float seconds = miliseconds / 1000.f;
+  float milliseconds = 0;
+  cudaEventElapsedTime(&milliseconds, start, stop);
+  float seconds = milliseconds / 1000.f;
   float rate = (float(dims.x * dims.y * dims.z) * sizeof(Scalar) ) / seconds;
   rate /= 1024.f;
   rate /= 1024.f;

--- a/src/template/encode.c
+++ b/src/template/encode.c
@@ -240,7 +240,7 @@ _t1(encode_ints, UInt)(bitstream* restrict_ stream, uint maxbits, uint maxprec, 
 {
   /* use fastest available encoder implementation */
   if (with_maxbits(maxbits, maxprec, size)) {
-    /* rate contrained path: encode partial bit planes */
+    /* rate constrained path: encode partial bit planes */
     if (size <= 64)
       return _t1(encode_few_ints, UInt)(stream, maxbits, maxprec, data, size); /* 1D, 2D, 3D blocks */
     else

--- a/tests/src/endtoend/serialExecBase.c
+++ b/tests/src/endtoend/serialExecBase.c
@@ -94,7 +94,7 @@ isCompressedBitrateComparableToChosenRate(struct setupVars* bundle)
   zfp_field* field = bundle->field;
   zfp_stream* stream = bundle->stream;
 
-  // integer arithemetic allows exact comparison
+  // integer arithmetic allows exact comparison
   size_t compressedBytes = zfp_compress(stream, field);
   if (compressedBytes == 0) {
     printf("Compression failed\n");


### PR DESCRIPTION
Not entirely sure about `contrained` → `constrained`