### PR TITLE
Set HIP_PATH in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,9 @@ if(ZFP_WITH_CUDA)
 endif()
 
 if(ZFP_WITH_HIP)
+  if (DEFINED ENV{HIP_PATH} AND NOT $ENV{HIP_PATH} STREQUAL "")
+    set(HIP_PATH $ENV{HIP_PATH} CACHE PATH "Path to where HIP has been installed")
+  endif()
   enable_language(HIP)
 endif()
 


### PR DESCRIPTION
This small PR simplifies the building of the HIP implementation of ZFP by setting the HIP_PATH automatically in the main CMakeLists.txt file, which avoids issues with generated Makefile having broken targets for `libamdhip64.so`. This avoids having to manually set `-DHIP_PATH=...` during configuration