### PR TITLE
Testing _WIN32 is enough, no need to test _WIN64

### DIFF
--- a/include/zfp/internal/zfp/types.h
+++ b/include/zfp/internal/zfp/types.h
@@ -66,7 +66,7 @@ typedef unsigned long ulong;
   typedef unsigned int uint32;
 
   /* determine 64-bit data model */
-  #if defined(_WIN32) || defined(_WIN64)
+  #if defined(_WIN32)
     /* assume ILP32 or LLP64 (MSVC, MinGW) */
     #define ZFP_LLP64 1
   #else


### PR DESCRIPTION
`_WIN32` is defined on all Windows compilation targets, either 32-bit or 64-bit. It was initially supposed to distinguish between 16-bit and 32-bit targets, and is now defined by all compilers on both 32-bit and 64-bit Windows compilation targets.

https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-140 https://learn.microsoft.com/en-us/windows/win32/winprog64/the-tools

Besides, this is consistent with the rest of the source files which only test `_WIN32` to detect Windows compilation targets.

https://github.com/LLNL/zfp/blob/d846d33fa3755a094141c7fe7947f2ffe35693c8/include/zfp/internal/array/memory.hpp#L7
https://github.com/LLNL/zfp/blob/d846d33fa3755a094141c7fe7947f2ffe35693c8/tests/utils/zfpTimer.h#L4
https://github.com/LLNL/zfp/blob/d846d33fa3755a094141c7fe7947f2ffe35693c8/tests/utils/zfpTimer.c#L5
https://github.com/LLNL/zfp/blob/d846d33fa3755a094141c7fe7947f2ffe35693c8/tests/utils/zfpTimer.c#L26
https://github.com/LLNL/zfp/blob/d846d33fa3755a094141c7fe7947f2ffe35693c8/tests/utils/zfpTimer.c#L42