### PR TITLE
Use explicit fallthroughs in encode.c

### DIFF
--- a/src/template/encode.c
+++ b/src/template/encode.c
@@ -11,16 +11,16 @@ _t1(pad_block, Scalar)(Scalar* p, size_t n, ptrdiff_t s)
   switch (n) {
     case 0:
       p[0 * s] = 0;
-      /* FALLTHROUGH */
+      __attribute__((fallthrough));
     case 1:
       p[1 * s] = p[0 * s];
-      /* FALLTHROUGH */
+      __attribute__((fallthrough));
     case 2:
       p[2 * s] = p[1 * s];
-      /* FALLTHROUGH */
+      __attribute__((fallthrough));
     case 3:
       p[3 * s] = p[0 * s];
-      /* FALLTHROUGH */
+      __attribute__((fallthrough));
     default:
       break;
   }


### PR DESCRIPTION
Using
```
__attribute__((fallthrough));
```
allows the compiler to check for implicit fallthroughs with `-Wimplicit-fallthrough`, which has found _many_ issues in the codebases I've used it on.

It would be helpful if ZFP, as a core dependency, could use explicit fallthroughs to facilitate such checking.