### PR TITLE
update cuda cmake code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 wheelhouse
 zfpy.egg-info
 modules
+build-*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.20)
 
 # Enable MACOSX_RPATH by default
 cmake_policy(SET CMP0042 NEW)
@@ -200,15 +200,8 @@ if(ZFP_WITH_OPENMP AND NOT OpenMP_C_LIBRARIES)
 endif()
 
 if(ZFP_WITH_CUDA)
-  # use CUDA_BIN_DIR hint
-  set(ENV{CUDA_BIN_PATH} ${CUDA_BIN_DIR})
-  find_package(CUDA)
-  if(NOT CUDA_FOUND)
-    message(FATAL_ERROR "ZFP_WITH_CUDA is enabled, but a CUDA installation was not found.")
-  endif()
-  if(${CUDA_VERSION_MAJOR} LESS 7)
-    message(FATAL_ERROR "zfp requires at least CUDA 7.0.")
-  endif()
+    enable_language(CUDA)
+    find_package(CUDAToolkit REQUIRED)
 endif()
 
 if(NOT (ZFP_BIT_STREAM_WORD_SIZE EQUAL 64))

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,15 +1,3 @@
-if(ZFP_WITH_CUDA)
-  set(CMAKE_CXX_FLAGS_PREVIOUS ${CMAKE_CXX_FLAGS})
-  set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fPIC" )
-
-  add_subdirectory(cuda_zfp)
-  cuda_include_directories(${PROJECT_SOURCE_DIR}/include)
-  cuda_wrap_srcs(zfp OBJ zfp_cuda_backend_obj cuda_zfp/cuZFP.cu OPTIONS ${CMAKE_CUDA_FLAGS})
-  set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS_PREVIOUS})
-  add_definitions(-DZFP_WITH_CUDA)
-endif()
-
-
 set(zfp_source
   zfp.c
   bitstream.c
@@ -23,9 +11,18 @@ set(zfp_source
   encode4f.c encode4d.c encode4i.c encode4l.c
   decode4f.c decode4d.c decode4i.c decode4l.c)
 
-add_library(zfp ${zfp_source}
-                ${zfp_cuda_backend_obj})
+add_library(zfp ${zfp_source})
 add_library(zfp::zfp ALIAS zfp)
+
+if(ZFP_WITH_CUDA)
+  add_subdirectory(cuda_zfp)
+  target_sources(zfp PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/cuda_zfp/cuZFP.cu)
+  target_compile_definitions(zfp PUBLIC -DZFP_WITH_CUDA)
+  target_link_libraries(zfp PRIVATE CUDA::cudart stdc++)
+  set_property(TARGET zfp PROPERTY POSITION_INDEPENDENT_CODE ON)
+endif()
+
+
 
 if(ZFP_WITH_OPENMP)
   target_link_libraries(zfp PRIVATE OpenMP::OpenMP_C)
@@ -39,10 +36,6 @@ if(WIN32 AND BUILD_SHARED_LIBS)
   # Define ZFP_SOURCE when compiling libzfp to export symbols to Windows DLL
   list(APPEND zfp_public_defs ZFP_SHARED_LIBS)
   list(APPEND zfp_private_defs ZFP_SOURCE)
-endif()
-
-if(ZFP_WITH_CUDA)
-  target_link_libraries(zfp PRIVATE ${CUDA_CUDART_LIBRARY} stdc++)
 endif()
 
 target_compile_definitions(zfp


### PR DESCRIPTION
Hi @lindstro, some students I am working with encountered problems building the CUDA version of ZFP using a new version of CMake (v3.27 and newer).  This is because the FindCUDA cmake package was disabled in favor of FindCUDAToolkit and CUDA language support in this version and will be removed in a future version after being deprecated in 3.10.  The replacement features were introduced in cmake 3.17, but I find they are stable after 3.20 (the new cmake minimum required version that I introduced here).

As I have documented here: https://robertu94.github.io/guides/dependencies.html#tooling-versions, cmake 3.20 is available on all major Linux distros for their normal support cycles except Ubuntu 20.04, and CMake 3.20 is available on this platforms via `pip install cmake` or other package management systems including spack.  Supporting cmake 3.17 also includes CentOS-7 until it is deprecated in July, but will not support Ubuntu 20.04 which only provides cmake 3.16.

Regardless if you adopt this patch or not the spack package for ZFP needs to be updated as it does not build the cuda variant after cmake 3.27 to something of the effect of `depends("cmake@:3.26", when="@:1.0.0+cuda")`

cc: @jtian0