### PR TITLE
Working pip install from setup.py

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -151,6 +151,14 @@ Regardless of the settings below, |libzfp| will always be built.
   GNU make default: off and ignored.
 
 
+  On systems with rpath (e.g. linux), it is also possible to
+  install the python bindings *after* installing the C
+  library (e.g. to /prefix_of_zfp/lib/libzfp.so)
+  by setting rpath during pip install:
+
+  LDFLAGS=-Wl,-rpath,/prefix_of_zfp/lib' pip install .
+
+
 .. c:macro:: BUILD_ZFORP
 
   Build |libzforp| for Fortran bindings to the C API.  Requires Fortran

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+# pyproject.toml
+[build-system]
+requires = ["setuptools", "cython", "numpy"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name="zfpy"
+version="1.0.1"
+authors = [ {name="Peter Lindstrom", email="zfp@llnl.gov"},
+            {name="Danielle Asher"} ]
+description="zfp compression in Python"
+requires-python = ">=3.0"

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,9 @@ from setuptools import setup, Extension
 import numpy as np
 
 setup(
-    name="zfpy",
-    version="1.0.1",
-    author="Peter Lindstrom, Danielle Asher",
-    author_email="zfp@llnl.gov",
     url="https://zfp.llnl.gov",
-    description="zfp compression in Python",
-    long_description="zfp is a compressed format for representing multidimensional floating-point and integer arrays. zfp provides compressed-array classes that support high throughput read and write random access to individual array elements. zfp also supports serial and parallel compression of whole arrays using both lossless and lossy compression with error tolerances. zfp is primarily written in C and C++ but also includes Python and Fortran bindings.",
-    ext_modules=[Extension("zfpy", ["build/python/zfpy.c"],
+    #long_description="zfp is a compressed format for representing multidimensional floating-point and integer arrays. zfp provides compressed-array classes that support high throughput read and write random access to individual array elements. zfp also supports serial and parallel compression of whole arrays using both lossless and lossy compression with error tolerances. zfp is primarily written in C and C++ but also includes Python and Fortran bindings.",
+    ext_modules=[Extension("zfpy", ["python/zfpy.pyx"],
                            include_dirs=["include", np.get_include()],
-                           libraries=["zfp"], library_dirs=["build/lib64", "build/lib/Release"]), language_level = "3"]
+                           libraries=["zfp"], library_dirs=["build/lib64", "build/lib"])],
 )


### PR DESCRIPTION
Explanation added to installation document.

Some setup.py options moved to pyproject.toml.
setup.py crashed when long_description
was left in though. So it was commented out.

Should consider setting license in pyproject.toml.