### PR TITLE
Cuda stream

### DIFF
--- a/docs/source/execution.rst
+++ b/docs/source/execution.rst
@@ -125,6 +125,18 @@ in use.  Future versions of |zfp| may allow specifying how threads are
 mapped to chunks, whether to use static or dynamic scheduling, etc.
 
 
+CUDA Stream
+^^^^^^^^^^^
+
+By default, all CUDA operations are performed on the default stream (also
+known as stream '0'). Using :c:func:`zfp_stream_set_cuda_stream` the user
+can specify a different, non-0 stream. This allows for potential overlap
+between execution units. For instance, when compressing two buffers and
+copying the results back to the host, using different streams for each
+would enable the second compression kernel to start concurrently with the
+transfer of the compressed first buffer.
+
+
 .. _exec-mode:
 
 Fixed- vs. Variable-Rate Compression

--- a/docs/source/high-level-api.rst
+++ b/docs/source/high-level-api.rst
@@ -699,6 +699,13 @@ Execution Policy
 
 ----
 
+.. c:function:: cudaStream_t zfp_stream_cuda_stream(zfp_stream* stream)
+
+   Return the stream on which CUDA operations are performed.
+   See :c:func:`zfp_stream_set_cuda_stream`.
+
+----
+
 .. c:function:: zfp_bool zfp_stream_set_execution(zfp_stream* stream, zfp_exec_policy policy)
 
   Set :ref:`execution policy <execution>`.  If different from the previous
@@ -723,6 +730,12 @@ Execution Policy
   If zero, use one chunk per thread.  This function also sets the execution
   policy to OpenMP.  Upon success, :code:`zfp_true` is returned.
 
+----
+
+.. c:function:: zfp_bool zfp_stream_set_cuda_stream(zfp_stream* stream, cudaStream_t custream)
+
+   Set the CUDA stream on which all CUDA operations will be performed. This function
+   also sets the execution policy to CUDA. Upon success, :code:`zfp_true` is returned.
 
 .. _hl-func-config:
 

--- a/include/zfp.h
+++ b/include/zfp.h
@@ -84,7 +84,7 @@ typedef struct {
 #ifdef ZFP_WITH_CUDA
 /* CUDA execution parameters */
 typedef struct {
-  cudaStream_t stream; /* */
+  cudaStream_t stream;  /* The stream on which to perform all CUDA operations */
 } zfp_exec_params_cuda;
 #endif
 
@@ -324,7 +324,7 @@ zfp_stream_omp_chunk_size(
 #ifdef ZFP_WITH_CUDA
 /* cuda stream */
 cudaStream_t
-zfp_stream_cuda_stream(    /* cuda stream */
+zfp_stream_cuda_stream(
   const zfp_stream* stream /* compressed stream */
 );
 #endif
@@ -351,10 +351,11 @@ zfp_stream_set_omp_chunk_size(
 );
 
 #ifdef ZFP_WITH_CUDA
+/* set CUDA stream on which to perform all CUDA operations */
 zfp_bool
 zfp_stream_set_cuda_stream(
-  zfp_stream* zfp,
-  cudaStream_t custream
+  zfp_stream* zfp,       /* compressed stream */
+  cudaStream_t custream  /* cuda stream */
 );
 #endif
 

--- a/include/zfp.h
+++ b/include/zfp.h
@@ -12,6 +12,10 @@
 #include "zfp/internal/zfp/system.h"
 #include "zfp/internal/zfp/types.h"
 
+#ifdef ZFP_WITH_CUDA
+#include <cuda_runtime_api.h>
+#endif
+
 /* macros ------------------------------------------------------------------ */
 
 /* default compression parameters */
@@ -76,6 +80,13 @@ typedef struct {
   uint threads;    /* number of requested threads */
   uint chunk_size; /* number of blocks per chunk (1D only) */
 } zfp_exec_params_omp;
+
+#ifdef ZFP_WITH_CUDA
+/* CUDA execution parameters */
+typedef struct {
+  cudaStream_t stream; /* */
+} zfp_exec_params_cuda;
+#endif
 
 typedef struct {
   zfp_exec_policy policy; /* execution policy (serial, omp, ...) */
@@ -310,6 +321,14 @@ zfp_stream_omp_chunk_size(
   const zfp_stream* stream /* compressed stream */
 );
 
+#ifdef ZFP_WITH_CUDA
+/* cuda stream */
+cudaStream_t
+zfp_stream_cuda_stream(    /* cuda stream */
+  const zfp_stream* stream /* compressed stream */
+);
+#endif
+
 /* set execution policy */
 zfp_bool                 /* true upon success */
 zfp_stream_set_execution(
@@ -330,6 +349,14 @@ zfp_stream_set_omp_chunk_size(
   zfp_stream* stream, /* compressed stream */
   uint chunk_size     /* number of blocks per chunk (0 for default) */
 );
+
+#ifdef ZFP_WITH_CUDA
+zfp_bool
+zfp_stream_set_cuda_stream(
+  zfp_stream* zfp,
+  cudaStream_t custream
+);
+#endif
 
 /* high-level API: compression mode and parameter settings ----------------- */
 

--- a/src/cuda_zfp/cuZFP.cu
+++ b/src/cuda_zfp/cuZFP.cu
@@ -348,6 +348,11 @@ void cleanup_device_ptr(void *orig_ptr, void *d_ptr, size_t bytes, long long int
   }
 
   cudaFreeAsync(d_offset_ptr, custream);
+
+  if(!custream) {
+      // Maintain blocking behavior if no stream was specified
+      cudaStreamSynchronize(0);
+  }
 }
 
 } // namespace internal

--- a/src/cuda_zfp/decode1.cuh
+++ b/src/cuda_zfp/decode1.cuh
@@ -81,7 +81,8 @@ size_t decode1launch(uint dim,
                      int stride,
                      Word *stream,
                      Scalar *d_data,
-                     uint maxbits)
+                     uint maxbits,
+                     cudaStream_t custream)
 {
   const int cuda_block_size = 128;
 
@@ -110,12 +111,12 @@ size_t decode1launch(uint dim,
   cudaEventCreate(&start);
   cudaEventCreate(&stop);
 
-  cudaEventRecord(start);
+  cudaEventRecord(start, custream);
 #endif
 
-  cudaDecode1<Scalar> << < grid_size, block_size >> >
+  cudaDecode1<Scalar> <<<grid_size, block_size, 0, custream>>>
     (stream,
-		 d_data,
+	 d_data,
      dim,
      stride,
      zfp_pad,
@@ -123,9 +124,9 @@ size_t decode1launch(uint dim,
      maxbits);
 
 #ifdef CUDA_ZFP_RATE_PRINT
-  cudaEventRecord(stop);
+  cudaEventRecord(stop, custream);
   cudaEventSynchronize(stop);
-	cudaStreamSynchronize(0);
+  cudaStreamSynchronize(custream);
 
   float milliseconds = 0;
   cudaEventElapsedTime(&milliseconds, start, stop);
@@ -136,6 +137,9 @@ size_t decode1launch(uint dim,
   rate /= 1024.f;
   printf("Decode elapsed time: %.5f (s)\n", seconds);
   printf("# decode1 rate: %.2f (GB / sec) %d\n", rate, maxbits);
+
+  cudaEventDestroy(start);
+  cudaEventDestroy(stop);
 #endif
   return stream_bytes;
 }
@@ -145,9 +149,10 @@ size_t decode1(int dim,
                int stride,
                Word *stream,
                Scalar *d_data,
-               uint maxbits)
+               uint maxbits,
+               cudaStream_t custream)
 {
-	return decode1launch<Scalar>(dim, stride, stream, d_data, maxbits);
+	return decode1launch<Scalar>(dim, stride, stream, d_data, maxbits, custream);
 }
 
 } // namespace cuZFP

--- a/src/cuda_zfp/decode3.cuh
+++ b/src/cuda_zfp/decode3.cuh
@@ -110,7 +110,8 @@ size_t decode3launch(uint3 dims,
                      int3 stride,
                      Word *stream,
                      Scalar *d_data,
-                     uint maxbits)
+                     uint maxbits,
+                     cudaStream_t custream)
 {
   const int cuda_block_size = 128;
   dim3 block_size;
@@ -147,21 +148,21 @@ size_t decode3launch(uint3 dims,
   cudaEventCreate(&start);
   cudaEventCreate(&stop);
 
-  cudaEventRecord(start);
+  cudaEventRecord(start, custream);
 #endif
 
-  cudaDecode3<Scalar, 64> << < grid_size, block_size >> >
+  cudaDecode3<Scalar, 64> <<<grid_size, block_size, 0, custream>>>
     (stream,
-		 d_data,
+	 d_data,
      dims,
      stride,
      zfp_pad,
      maxbits);
 
 #ifdef CUDA_ZFP_RATE_PRINT
-  cudaEventRecord(stop);
+  cudaEventRecord(stop, custream);
   cudaEventSynchronize(stop);
-	cudaStreamSynchronize(0);
+  cudaStreamSynchronize(custream);
 
   float milliseconds = 0;
   cudaEventElapsedTime(&milliseconds, start, stop);
@@ -172,6 +173,9 @@ size_t decode3launch(uint3 dims,
   rate /= 1024.f;
   printf("Decode elapsed time: %.5f (s)\n", seconds);
   printf("# decode3 rate: %.2f (GB / sec) %d\n", rate, maxbits);
+
+  cudaEventDestroy(start);
+  cudaEventDestroy(stop);
 #endif
 
   return stream_bytes;
@@ -182,9 +186,10 @@ size_t decode3(uint3 dims,
                int3 stride,
                Word  *stream,
                Scalar *d_data,
-               uint maxbits)
+               uint maxbits,
+               cudaStream_t custream)
 {
-	return decode3launch<Scalar>(dims, stride, stream, d_data, maxbits);
+	return decode3launch<Scalar>(dims, stride, stream, d_data, maxbits, custream);
 }
 
 } // namespace cuZFP

--- a/src/cuda_zfp/encode3.cuh
+++ b/src/cuda_zfp/encode3.cuh
@@ -119,7 +119,8 @@ size_t encode3launch(uint3 dims,
                      int3 stride,
                      const Scalar *d_data,
                      Word *stream,
-                     const int maxbits)
+                     const int maxbits,
+                     cudaStream_t custream)
 {
 
   const int cuda_block_size = 128;
@@ -148,16 +149,16 @@ size_t encode3launch(uint3 dims,
 
   size_t stream_bytes = calc_device_mem3d(zfp_pad, maxbits);
   //ensure we start with 0s
-  cudaMemset(stream, 0, stream_bytes);
+  cudaMemsetAsync(stream, 0, stream_bytes, custream);
 
 #ifdef CUDA_ZFP_RATE_PRINT
   cudaEvent_t start, stop;
   cudaEventCreate(&start);
   cudaEventCreate(&stop);
-  cudaEventRecord(start);
+  cudaEventRecord(start, custream);
 #endif
 
-  cudaEncode<Scalar> <<<grid_size, block_size>>>
+  cudaEncode<Scalar> <<<grid_size, block_size, 0, custream>>>
     (maxbits,
      d_data,
      stream,
@@ -167,9 +168,9 @@ size_t encode3launch(uint3 dims,
      zfp_blocks);
 
 #ifdef CUDA_ZFP_RATE_PRINT
-  cudaEventRecord(stop);
+  cudaEventRecord(stop, custream);
   cudaEventSynchronize(stop);
-  cudaStreamSynchronize(0);
+  cudaStreamSynchronize(custream);
 
   float milliseconds = 0;
   cudaEventElapsedTime(&milliseconds, start, stop);
@@ -180,6 +181,9 @@ size_t encode3launch(uint3 dims,
   rate /= 1024.f;
   printf("Encode elapsed time: %.5f (s)\n", seconds);
   printf("# encode3 rate: %.2f (GB / sec) \n", rate);
+
+  cudaEventDestroy(start);
+  cudaEventDestroy(stop);
 #endif
   return stream_bytes;
 }
@@ -192,9 +196,10 @@ size_t encode(uint3 dims,
               int3 stride,
               Scalar *d_data,
               Word *stream,
-              const int bits_per_block)
+              const int bits_per_block,
+              cudaStream_t custream)
 {
-  return encode3launch<Scalar>(dims, stride, d_data, stream, bits_per_block);
+  return encode3launch<Scalar>(dims, stride, d_data, stream, bits_per_block, custream);
 }
 
 }


### PR DESCRIPTION
This PR provides support for running CUDA compression / decompression on a CUDA [stream](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#streams). This allows for potential overlap between memory transfers and kernel execution, or memory transfers in different directions on devices that support it. Overlapping transfers and execution enables large performance gains in certain scenarios.

To that end I've introduced a `zfp_exec_params_cuda` struct (similar to `zfp_exec_params_omp`) that contains a `cudaStream_t` member. Setting and querying the stream can be done using the new `zfp_stream_set_cuda_stream` and `zfp_stream_cuda_stream` functions.

When no stream is specified, the default 0-stream is used. Since several CUDA calls in the code have been changed to their `*Async` equivalent, a `cudaStreamSynchronize(0)` is performed when stream 0 is used, to retain blocking behavior in that case.