### PR TITLE
Add native AArch64 Linux CI test jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,20 @@ jobs:
             omp: ON
             target: all
             
+          - os: ubuntu-24.04-arm
+            cxx_compiler: g++-14
+            c_compiler: gcc-14
+            omp: ON
+            target: all
+            architecture: arm64
+            
+          - os: ubuntu-24.04-arm
+            cxx_compiler: clang++
+            c_compiler: clang
+            omp: ON
+            target: all
+            architecture: arm64
+            
           - os: macos-latest
             cxx_compiler: g++-12
             c_compiler: gcc-12
@@ -43,7 +57,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
-          architecture: x64
+          architecture: ${{ matrix.architecture || 'x64' }}
 
       - name: Install zfpy dependencies
         run: |
@@ -52,7 +66,7 @@ jobs:
           python -m pip install setuptools
       
       - name: Setup OpenMP (Linux)
-        if: ${{matrix.os == 'ubuntu-latest' && matrix.cxx_compiler == 'clang++'}}
+        if: ${{(matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm') && matrix.cxx_compiler == 'clang++'}}
         run: sudo apt-get update; sudo apt-get install -y libomp5 libomp-dev
 
       - name: Setup OpenMP (MacOS)


### PR DESCRIPTION
GitHub has made arm64 hosted-runners available free to public/open source repositories: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

Here are the results from running the CI tests with the changes made to the build matrix: https://github.com/nightlark/zfp/actions/runs/12837515115

Unfortunately they haven't added anything like a `ubuntu-latest-arm` label, but there have been a number of people commenting on their various announcement posts asking for one... so we'll see if they change their stance.