### PR TITLE
Enable CMake languages in ZFP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ else()
     "${ZFP_VERSION_MAJOR}.${ZFP_VERSION_MINOR}.${ZFP_VERSION_PATCH}.${ZFP_VERSION_TWEAK}")
 endif()
 
-project(ZFP VERSION ${ZFP_VERSION})
+project(ZFP VERSION ${ZFP_VERSION} LANGUAGES C CXX)
 
 #------------------------------------------------------------------------------#
 # Some boilerplate to setup nice output directories
@@ -200,6 +200,7 @@ if(ZFP_WITH_OPENMP AND NOT OpenMP_C_LIBRARIES)
 endif()
 
 if(ZFP_WITH_CUDA)
+  enable_language(CUDA)
   # use CUDA_BIN_DIR hint
   set(ENV{CUDA_BIN_PATH} ${CUDA_BIN_DIR})
   find_package(CUDA)


### PR DESCRIPTION
I encountered an error when adding ZFP to [this project](https://gitlab.mpcdf.mpg.de/bsl6d/bsl6d/-/blob/119-data-compressed-halo-exchange/cmake/BSL6DZfpConfig.cmake?ref_type=heads) using FetchContent

If ZFP is build with CUDA capabilities this leads to a delayed error stating missing CMAKE_CUDA_CREATE_STATIC_LIBRARY, which seems to be a configuration option for windows.
```
CMake Error: Error required internal CMake variable not set, cmake may not be built correctly.
Missing variable is:
CMAKE_CUDA_CREATE_STATIC_LIBRARY
```

This can be avoided if CUDA is enabled as a language explicitly in the project. This error is thrown only, if `enable_language(CUDA)` is called at a later stage which in our case is done by the HeFFTe subproject.

Minimal reproducable with cmake/4.0, gcc/12, cuda/12.2:
```sh
cmake -S . -B build -D CMAKE_CXX_COMPILER=g++ -D CMAKE_C_COMPILER=gcc
```
[minimalZFP_fetchContent.zip](https://github.com/user-attachments/files/21666279/minimalZFP_fetchContent.zip)
