### PR TITLE
Pin GHA dependencies by hash

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,10 +11,10 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6
         with:
           python-version: '3.x'
           architecture: x64
@@ -42,7 +42,7 @@ jobs:
           lcov_cobertura ${{github.workspace}}/build/coverage.info -d -o ${{github.workspace}}/build/coverage.xml
 
       - name: Upload Report to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         with:
            files: ${{github.workspace}}/build/coverage.xml
            env_vars: Actions

--- a/.github/workflows/debug-linux.yml
+++ b/.github/workflows/debug-linux.yml
@@ -7,10 +7,10 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Checkout Zfp
-          uses: actions/checkout@v6
+          uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
         - name: Setup Python
-          uses: actions/setup-python@v6
+          uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6
           with:
             python-version: '3.x'
             architecture: x64
@@ -26,4 +26,4 @@ jobs:
             sudo apt-get update; sudo apt-get install -y libomp5 libomp-dev
 
         - name: Setup Tmate Session
-          uses: mxschmitt/action-tmate@v3
+          uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101 # v3

--- a/.github/workflows/debug-macos.yml
+++ b/.github/workflows/debug-macos.yml
@@ -7,10 +7,10 @@ jobs:
       runs-on: macos-latest
       steps:
         - name: Checkout Zfp
-          uses: actions/checkout@v6
+          uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
         - name: Setup Python
-          uses: actions/setup-python@v6
+          uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6
           with:
             python-version: '3.x'
             architecture: x64
@@ -26,4 +26,4 @@ jobs:
             brew install libomp
 
         - name: Setup Tmate Session
-          uses: mxschmitt/action-tmate@v3
+          uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101 # v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,10 +56,10 @@ jobs:
             target: all
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6
         with:
           python-version: '3.x'
           architecture: ${{ matrix.architecture || 'x64' }}


### PR DESCRIPTION
Hash-pinned dependencies are an important requirement enforced by the OpenSSF scorecard tool: https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies

This commit pins all GitHub Actions workflows to a commit hash.