### PR TITLE
Restrict workflow permissions to minimum required

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,9 @@ on:
     workflows: [Tests]
     types: [completed]
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/debug-linux.yml
+++ b/.github/workflows/debug-linux.yml
@@ -2,6 +2,9 @@ name: Debug (Linux)
 
 on: [workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
     debug:
       runs-on: ubuntu-latest

--- a/.github/workflows/debug-macos.yml
+++ b/.github/workflows/debug-macos.yml
@@ -2,6 +2,9 @@ name: Debug (MacOS)
 
 on: [workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
     debug:
       runs-on: macos-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,9 @@ name: Tests
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 env:
   BUILD_TYPE: Release
 


### PR DESCRIPTION
Limiting the scope of the GITHUB_TOKEN via the [permissions](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions) attribute is best practice to prevent a leaked GITHUB_TOKEN from allowing repository write access.