### PR TITLE
Instructions for Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ zfp may also be built using GNU make:
 Note: GNU builds are less flexible and do not support all available features,
 e.g., CUDA support.
 
+Alternatively, zfp may be installed using [Homebrew](https://brew.sh):
+
+    brew install zfp
+
 For further configuration and build instructions, please consult the
 [documentation](https://zfp.readthedocs.io/en/release1.0.1/installation.html).
 For examples of how to call the C library and use the C++ array classes,

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -80,6 +80,12 @@ command-line utility.  To enable OpenMP parallel compression, type::
   CUDA and Python support are not included.  For full functionality,
   build |zfp| using CMake.
 
+Homebrew 
+----------
+
+If you use Homebrew, zfp can be installed as follows::
+
+    brew install zfp
 
 Testing
 -------


### PR DESCRIPTION
`zfp` is now [available](https://github.com/Homebrew/homebrew-core/commit/b20e144e3e236ae89b04ccea9374d2fd0ae8d8f7) to install with [Homebrew](https://brew.sh).